### PR TITLE
Support Android build

### DIFF
--- a/src/algo/constants.h
+++ b/src/algo/constants.h
@@ -1,0 +1,10 @@
+#pragma once
+
+namespace sota {
+
+// C++ 20 not available for Android build => can't include <numbers>
+// M_PI may not compile for Windows.
+// So, as a workaround, declare PI here
+constexpr double PI = 3.14159265;
+
+}  // namespace sota

--- a/src/core/hex_mesh.cpp
+++ b/src/core/hex_mesh.cpp
@@ -1,8 +1,8 @@
 #include "hex_mesh.h"
 
 #include <array>
-#include <numbers>
 
+#include "algo/constants.h"
 #include "core/utils.h"
 #include "godot_cpp/core/class_db.hpp"
 #include "godot_cpp/variant/array.hpp"
@@ -86,8 +86,7 @@ void HexMesh::set_diameter(const float p_diameter) {
   R = radius(diameter);
   r = small_radius(diameter);
 
-  constexpr double pi = std::numbers::pi;
-  for (float i = -pi / 6; i < 11 * pi / 6; i += pi / 3) {
+  for (float i = -PI / 6; i < 11 * PI / 6; i += PI / 3) {
     _corner_points[i] = {std::cos(i) * R, 0, std::sin(i) * R};
   }
 

--- a/src/core/hexagonal_utility.cpp
+++ b/src/core/hexagonal_utility.cpp
@@ -14,7 +14,7 @@ std::vector<std::vector<Vector3i>> HexagonalUtility::get_offset_coords_layout(in
   auto r_end = [size](int q) { return q <= 0 ? size : size - q; };
   for (int q = -size; q <= size; ++q) {
     for (int r = r_start(q); r <= r_end(q); ++r) {
-      auto cube = CubeCoordinates(q, r, -q - r);
+      auto cube = CubeCoordinates{.q = q, .r = r, .s = -q - r};
       auto offset_coord = cubeToOffset(cube);
       if (is_odd(size) && is_odd(offset_coord.row)) {
         ++offset_coord.col;

--- a/src/core/utils.cpp
+++ b/src/core/utils.cpp
@@ -1,7 +1,8 @@
 #include "core/utils.h"
 
 #include <cmath>
-#include <numbers>
+
+#include "algo/constants.h"  //
 
 namespace sota {
 
@@ -16,8 +17,7 @@ bool epsilonEqual(float lhs, float rhs) { return std::abs(lhs - rhs) < EPSILON; 
 bool epsilonEqual(float lhs, float rhs, float tol) { return std::abs(lhs - rhs) < tol; }
 bool epsilonNotEqual(float lhs, float rhs) { return !epsilonEqual(lhs, rhs); }
 double cosrp(double a, double b, double mu) {
-  constexpr double pi = std::numbers::pi;
-  double mu2 = (1 - std::cos(mu * pi)) / 2;
+  double mu2 = (1 - std::cos(mu * PI)) / 2;
   return a * (1 - mu2) + b * mu2;
 };
 

--- a/src/misc/cube_coordinates.cpp
+++ b/src/misc/cube_coordinates.cpp
@@ -8,14 +8,14 @@ namespace sota {
 OffsetCoordinates cubeToOffset(CubeCoordinates coord) {
   int col = coord.q + (coord.r - (coord.r & 1)) / 2;
   int row = -coord.r;
-  return OffsetCoordinates(row, col);
+  return OffsetCoordinates{.row = row, .col = col};
 }
 
 // odd-r to cube conversion
 CubeCoordinates offsetToCube(OffsetCoordinates coord) {
   int q = coord.col + ((coord.row & 1) + coord.row) / 2;
   int r = -coord.row;
-  return CubeCoordinates(q, r, -q - r);
+  return CubeCoordinates{.q = q, .r = r, .s = -q - r};
 }
 
 bool operator==(const CubeCoordinates& lhs, const CubeCoordinates& rhs) {

--- a/src/ridge_impl/mountain_hex_mesh.cpp
+++ b/src/ridge_impl/mountain_hex_mesh.cpp
@@ -10,7 +10,7 @@ using namespace gd;
 constexpr float top_y_offset = 0.5;
 
 void MountainHexMesh::calculate_final_heights() {
-  calculate_ridge_based_heights(std::lerp<double, double, double>, top_y_offset);
+  calculate_ridge_based_heights([](double a, double b, double c) { return std::lerp(a, b, c); }, top_y_offset);
 }
 
 }  // namespace sota

--- a/src/ridge_impl/ridge_hex_mesh.cpp
+++ b/src/ridge_impl/ridge_hex_mesh.cpp
@@ -137,12 +137,12 @@ void RidgeHexMesh::calculate_ridge_based_heights(std::function<double(double, do
     v.y -= std::lerp(0, n, t_perlin(v.y));
   }
 
-  _min_y = std::min_element(vertices_.begin(), vertices_.end(), [](const auto& v1, const auto& v2) {
-             return v1.y < v2.y;
-           })->y;
-  _max_y = std::max_element(vertices_.begin(), vertices_.end(), [](const auto& v1, const auto& v2) {
-             return v1.y < v2.y;
-           })->y;
+  for (auto& v : vertices_) {
+    _min_y = std::min(_min_y, v.y);
+  }
+  for (auto& v : vertices_) {
+    _max_y = std::max(_max_y, v.y);
+  }
 }
 
 void RidgeHexMesh::calculate_initial_heights() {


### PR DESCRIPTION
Support older clang 12 version.
Godot currently supports NDK 23.2.8568313. To be able to compile Sota
for Android fix compilation error. Clang version from downloaded NDK:

Android (8481493, based on r416183c2) clang version 12.0.9
Target: x86_64-unknown-linux-gnu
Thread model: posix

Resolves: #2 