### PR TITLE
Add DummyMesher class

### DIFF
--- a/src/core/dummy_mesher.cpp
+++ b/src/core/dummy_mesher.cpp
@@ -1,0 +1,78 @@
+#include "core/dummy_mesher.h"
+
+#include "godot_cpp/variant/color.hpp"
+#include "godot_cpp/variant/packed_byte_array.hpp"
+#include "godot_cpp/variant/packed_color_array.hpp"
+#include "godot_cpp/variant/packed_float32_array.hpp"
+#include "godot_cpp/variant/packed_int32_array.hpp"
+#include "godot_cpp/variant/packed_vector2_array.hpp"
+#include "godot_cpp/variant/vector2.hpp"
+
+namespace sota {
+
+using namespace godot;
+
+PackedFloat32Array DummyMesher::calculate_tangents(int n) {
+  PackedFloat32Array result;
+  result.resize(n * 4);
+  result.fill(0);
+  return result;
+}
+
+PackedColorArray DummyMesher::calculate_colors(int n) {
+  PackedColorArray result;
+  result.resize(n);
+  result.fill(Color(0, 0, 0));
+  return result;
+}
+
+PackedVector2Array DummyMesher::calculate_tex_uv2(int n) {
+  PackedVector2Array result;
+  result.resize(n);
+  result.fill(Vector2(0, 0));
+  return result;
+}
+
+PackedByteArray DummyMesher::calculate_color_custom0(int n) {
+  PackedByteArray result;
+  result.resize(4 * n);
+  result.fill(0);
+  return result;
+}
+
+PackedByteArray DummyMesher::calculate_color_custom1(int n) {
+  PackedByteArray result;
+  result.resize(4 * n);
+  result.fill(0);
+  return result;
+}
+
+PackedByteArray DummyMesher::calculate_color_custom2(int n) {
+  PackedByteArray result;
+  result.resize(4 * n);
+  result.fill(0);
+  return result;
+}
+
+PackedByteArray DummyMesher::calculate_color_custom3(int n) {
+  PackedByteArray result;
+  result.resize(4 * n);
+  result.fill(0);
+  return result;
+}
+
+PackedInt32Array DummyMesher::calculate_bones(int n) {
+  PackedInt32Array result;
+  result.resize(4 * n);
+  result.fill(0);
+  return result;
+}
+
+PackedFloat32Array DummyMesher::calculate_weights(int n) {
+  PackedFloat32Array result;
+  result.resize(4 * n);
+  result.fill(0);
+  return result;
+}
+
+}  // namespace sota

--- a/src/core/dummy_mesher.h
+++ b/src/core/dummy_mesher.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "godot_cpp/variant/packed_byte_array.hpp"
+#include "godot_cpp/variant/packed_color_array.hpp"
+#include "godot_cpp/variant/packed_float32_array.hpp"
+#include "godot_cpp/variant/packed_int32_array.hpp"
+#include "godot_cpp/variant/packed_vector2_array.hpp"
+
+namespace sota {
+
+class DummyMesher {
+ public:
+  static godot::PackedFloat32Array calculate_tangents(int n);
+  static godot::PackedColorArray calculate_colors(int n);
+  static godot::PackedVector2Array calculate_tex_uv2(int n);
+  static godot::PackedByteArray calculate_color_custom0(int n);
+  static godot::PackedByteArray calculate_color_custom1(int n);
+  static godot::PackedByteArray calculate_color_custom2(int n);
+  static godot::PackedByteArray calculate_color_custom3(int n);
+  static godot::PackedInt32Array calculate_bones(int n);
+  static godot::PackedFloat32Array calculate_weights(int n);
+};
+
+}  // namespace sota

--- a/src/core/mesh.cpp
+++ b/src/core/mesh.cpp
@@ -1,6 +1,6 @@
 #include "core/mesh.h"
 
-#include "godot_cpp/variant/vector2.hpp"
+#include "dummy_mesher.h"
 #include "godot_cpp/variant/vector3.hpp"
 
 namespace sota {
@@ -50,21 +50,9 @@ void SotaMesh::calculate_normals() const {
   }
 }
 
-void SotaMesh::calculate_tangents() const {
-  tangents_.clear();
-  int n = vertices_.size();
-  for (int i = 0; i < n; ++i) {
-    tangents_.append_array({1, 0, 0, 1});
-  }
-}
+void SotaMesh::calculate_tangents() const { tangents_ = DummyMesher::calculate_tangents(vertices_.size()); }
 
-void SotaMesh::calculate_colors() const {
-  colors_.clear();
-  int n = vertices_.size();
-  for (int i = 0; i < n; ++i) {
-    colors_.push_back(Color(0, 0, 0));
-  }
-}
+void SotaMesh::calculate_colors() const { colors_ = DummyMesher::calculate_colors(vertices_.size()); }
 
 void SotaMesh::calculate_indices() const {
   indices_.clear();
@@ -73,35 +61,18 @@ void SotaMesh::calculate_indices() const {
     indices_.append_array({i, i + 1, i + 2});
   }
 }
-void SotaMesh::calculate_tex_uv2() const {
-  tex_uv2_.clear();
-  for (const auto& v : vertices_) {
-    tex_uv2_.push_back(Vector2{0, 0});
-  }
-}
+void SotaMesh::calculate_tex_uv2() const { tex_uv2_ = DummyMesher::calculate_tex_uv2(vertices_.size()); }
 
 void SotaMesh::calculate_color_custom() const {
-  color_custom0_.clear();
-  color_custom1_.clear();
-  color_custom2_.clear();
-  color_custom3_.clear();
-  int n = vertices_.size();
-  for (int i = 0; i < n; ++i) {
-    color_custom0_.append_array({0, 0, 0, 0});
-    color_custom1_.append_array({0, 0, 0, 0});
-    color_custom2_.append_array({0, 0, 0, 0});
-    color_custom3_.append_array({0, 0, 0, 0});
-  }
+  color_custom0_ = DummyMesher::calculate_color_custom0(vertices_.size());
+  color_custom1_ = DummyMesher::calculate_color_custom0(vertices_.size());
+  color_custom2_ = DummyMesher::calculate_color_custom0(vertices_.size());
+  color_custom3_ = DummyMesher::calculate_color_custom0(vertices_.size());
 }
 
 void SotaMesh::calculate_bones_weights() const {
-  bones_.clear();
-  weights_.clear();
-  int n = vertices_.size();
-  for (int i = 0; i < n; ++i) {
-    bones_.append_array({0, 0, 0, 0});
-    weights_.append_array({0, 0, 0, 0});
-  }
+  bones_ = DummyMesher::calculate_bones(vertices_.size());
+  weights_ = DummyMesher::calculate_weights(vertices_.size());
 }
 
 Array SotaMesh::_create_mesh_array() const {
@@ -123,11 +94,11 @@ Array SotaMesh::_create_mesh_array() const {
 }
 
 void SotaMesh::recalculate_all_except_vertices() const {
-  calculate_indices();  // normals depends on indices. Calculate them first
+  calculate_indices();
   calculate_normals();
+  calculate_tex_uv1();
   calculate_tangents();
   calculate_colors();
-  calculate_tex_uv1();
   calculate_tex_uv2();
   calculate_color_custom();
   calculate_bones_weights();

--- a/src/core/mesh.h
+++ b/src/core/mesh.h
@@ -35,9 +35,6 @@ class SotaMesh : public godot::PrimitiveMesh {
   int id;
   int divisions{1};
 
-  static void _bind_methods();
-  virtual void init_impl() = 0;
-
   mutable godot::PackedVector3Array vertices_;
   mutable godot::PackedVector3Array normals_;
   mutable godot::PackedFloat32Array tangents_;
@@ -51,6 +48,9 @@ class SotaMesh : public godot::PrimitiveMesh {
   mutable godot::PackedByteArray color_custom3_;
   mutable godot::PackedInt32Array bones_;
   mutable godot::PackedFloat32Array weights_;
+
+  static void _bind_methods();
+  virtual void init_impl() = 0;
 
   void calculate_tangents() const;
   void calculate_colors() const;


### PR DESCRIPTION
It provides dummy information to fill properties required by `_create_mesh_array()` virtual method. Use DummyMesher instead of doing the same in SotaMesh base class

Resolves: #13 