### PR TITLE
Make tiles children of grids

### DIFF
--- a/src/core/hex_grid_map.cpp
+++ b/src/core/hex_grid_map.cpp
@@ -1,7 +1,5 @@
 #include "core/hex_grid_map.h"
 
-#include <memory>
-
 #include "core/hex_mesh.h"
 #include "core/utils.h"
 #include "cube_coordinates.h"
@@ -9,8 +7,8 @@
 #include "godot_cpp/classes/shader.hpp"
 #include "godot_cpp/classes/shader_material.hpp"
 #include "godot_cpp/core/class_db.hpp"
-#include "godot_cpp/core/memory.hpp"
 #include "godot_cpp/core/object.hpp"
+#include "godot_cpp/variant/array.hpp"
 #include "godot_cpp/variant/callable.hpp"
 #include "godot_cpp/variant/vector2.hpp"
 #include "godot_cpp/variant/vector3.hpp"
@@ -27,6 +25,7 @@ using namespace gd;
 void HexGridMap::_bind_methods() {
   ClassDB::bind_method(D_METHOD("init"), &HexGridMap::init);
 
+  // Properties
   ClassDB::bind_method(D_METHOD("get_divisions"), &HexGridMap::get_divisions);
   ClassDB::bind_method(D_METHOD("set_divisions", "p_divisions"), &HexGridMap::set_divisions);
   ADD_PROPERTY(PropertyInfo(Variant::INT, "divisions"), "set_divisions", "get_divisions");
@@ -90,13 +89,13 @@ bool HexGridMap::get_frame_state() const { return frame_state; }
 float HexGridMap::get_frame_offset() const { return frame_offset; }
 
 void HexGridMap::init_hexmesh() {
-  _tiles_layout.clear();
   TypedArray<Node> children = get_children();
   for (int i = 0; i < children.size(); ++i) {
     Node* child = Object::cast_to<Node>(children[i].operator Object*());
     remove_child(child);
     child->queue_free();
   }
+  _tiles_layout.clear();
 
   for (auto row : col_row_layout) {
     _tiles_layout.push_back({});
@@ -125,7 +124,7 @@ void HexGridMap::init_hexmesh() {
       Ref<HexMesh> m = make_hex_mesh(hex, params);
 
       _tiles_layout.back().push_back(
-          std::make_unique<Tile>(m, offset, this, OffsetCoordinates{.row = val.x, .col = val.z}));
+          make_non_ref<Tile>(m, offset, this, OffsetCoordinates{.row = val.x, .col = val.z}));
     }
   }
 }

--- a/src/core/hex_grid_map.h
+++ b/src/core/hex_grid_map.h
@@ -9,6 +9,7 @@
 #include "godot_cpp/classes/node3d.hpp"
 #include "godot_cpp/classes/shader.hpp"
 #include "godot_cpp/classes/wrapped.hpp"
+#include "godot_cpp/variant/array.hpp"
 #include "godot_cpp/variant/vector3i.hpp"
 #include "misc/cube_coordinates.h"
 #include "misc/tile.h"
@@ -16,15 +17,13 @@
 
 namespace sota {
 
-using TilesLayout = std::vector<std::vector<std::unique_ptr<Tile>>>;
+using TilesLayout = std::vector<std::vector<Tile*>>;
 
 class HexGridMap : public gd::Node3D {
   GDCLASS(HexGridMap, gd::Node3D)
 
  public:
   HexGridMap() = default;
-
-  void _ready() override;
 
   void set_shader(const gd::Ref<gd::Shader> p_shader);
   gd::Ref<gd::Shader> get_shader() const;

--- a/src/core/hex_mesh.h
+++ b/src/core/hex_mesh.h
@@ -40,7 +40,6 @@ class HexMesh : public SotaMesh {
   float get_diameter() const;
   gd::Vector3 get_center() const { return _hex.center(); }
 
-  void init_impl() override;
   void update();
 
   void set_frame_state(bool state) { frame_state = state; }
@@ -54,6 +53,7 @@ class HexMesh : public SotaMesh {
   HexMesh(Hexagon hex, HexMeshParams params);
   HexMesh(Hexagon hex);
   static void _bind_methods();
+  void init_impl() override;
 
   void calculate_vertices_recursion();  // not tested e.g. for clips
   void calculate_vertices_iteration() const;

--- a/src/core/utils.h
+++ b/src/core/utils.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "godot_cpp/core/memory.hpp"
 #include "godot_cpp/variant/array.hpp"
 #include "godot_cpp/variant/packed_vector3_array.hpp"
 #include "godot_cpp/variant/vector2.hpp"
@@ -29,5 +30,10 @@ auto ico_points() -> godot::PackedVector3Array;
 auto ico_indices() -> godot::Array;
 auto barycentric(godot::Vector2 point) -> godot::Vector3;
 auto map2d_to_3d(godot::Vector2 point, godot::Vector3 s1, godot::Vector3 s2, godot::Vector3 s3) -> godot::Vector3;
+
+template <typename T, typename... Args>
+T* make_non_ref(Args... args) {
+  return memnew(T(args...));
+}
 
 }  // namespace sota

--- a/src/honeycomb/honeycomb.cpp
+++ b/src/honeycomb/honeycomb.cpp
@@ -221,7 +221,7 @@ Array Honeycomb::get_cells_by_order(SortingOrder order, std::function<bool(Honey
   std::vector<std::pair<int, HoneycombHoney*>> all_cells;
   for (auto& row : _tiles_layout) {
     for (auto& tile_ptr : row) {
-      HoneycombTile* tile = dynamic_cast<HoneycombTile*>(tile_ptr.get());
+      HoneycombTile* tile = dynamic_cast<HoneycombTile*>(tile_ptr);
       HoneycombHoney* cell = tile->honey_mesh().ptr();
       if (pred(cell)) {
         all_cells.emplace_back(cell->get_level(), cell);
@@ -244,7 +244,7 @@ Array Honeycomb::get_cells() const {
   Array res;
   for (auto& row : _tiles_layout) {
     for (auto& tile_ptr : row) {
-      HoneycombTile* tile = dynamic_cast<HoneycombTile*>(tile_ptr.get());
+      HoneycombTile* tile = dynamic_cast<HoneycombTile*>(tile_ptr);
       HoneycombHoney* cell = tile->honey_mesh().ptr();
       res.append(Ref(cell));
     }
@@ -269,7 +269,7 @@ Array Honeycomb::get_max_cells() const {
 bool Honeycomb::all_cells_empty() const {
   for (auto& row : _tiles_layout) {
     for (auto& tile_ptr : row) {
-      HoneycombTile* tile = dynamic_cast<HoneycombTile*>(tile_ptr.get());
+      HoneycombTile* tile = dynamic_cast<HoneycombTile*>(tile_ptr);
       HoneycombHoney* cell = tile->honey_mesh().ptr();
       if (!cell->is_empty()) {
         return false;
@@ -366,7 +366,7 @@ void Honeycomb::init_hexmesh() {
       Ref<HoneycombHoney> honey = make_honeycomb_honey(honey_hex, honey_params);
 
       _tiles_layout.back().push_back(
-          std::make_unique<HoneycombTile>(cell, honey, this, OffsetCoordinates{.row = val.x, .col = val.z}));
+          make_non_ref<HoneycombTile>(cell, honey, this, OffsetCoordinates{.row = val.x, .col = val.z}));
     }
   }
 }
@@ -397,7 +397,7 @@ void Honeycomb::calculate_flat_normals() {
     for (auto& tile_ptr : row) {
       tile_ptr->mesh()->calculate_normals();
 
-      HoneycombTile* tile = dynamic_cast<HoneycombTile*>(tile_ptr.get());
+      HoneycombTile* tile = dynamic_cast<HoneycombTile*>(tile_ptr);
       tile->honey_mesh()->calculate_normals();
     }
   }
@@ -407,7 +407,7 @@ void Honeycomb::meshes_update() {
   for (auto& row : _tiles_layout) {
     for (auto& tile_ptr : row) {
       tile_ptr->mesh()->update();
-      dynamic_cast<HoneycombTile*>(tile_ptr.get())->honey_mesh()->update();
+      dynamic_cast<HoneycombTile*>(tile_ptr)->honey_mesh()->update();
     }
   }
 }
@@ -423,7 +423,7 @@ void Honeycomb::calculate_smooth_normals() {
   std::vector<GroupedHexagonMeshVertices> honey_vertex_groups;
   for (auto& row : _tiles_layout) {
     for (auto& tile_ptr : row) {
-      HoneycombTile* tile = dynamic_cast<HoneycombTile*>(tile_ptr.get());
+      HoneycombTile* tile = dynamic_cast<HoneycombTile*>(tile_ptr);
       honey_vertex_groups.push_back(tile->honey_mesh()->get_grouped_vertices());
     }
   }
@@ -437,7 +437,7 @@ void Honeycomb::prepare_heights_calculation() {
   float global_max_y = std::numeric_limits<float>::min();
   for (auto& row : _tiles_layout) {
     for (auto& tile_ptr : row) {
-      HoneycombTile* tile = dynamic_cast<HoneycombTile*>(tile_ptr.get());
+      HoneycombTile* tile = dynamic_cast<HoneycombTile*>(tile_ptr);
       HoneycombHoney* honey_mesh = tile->honey_mesh().ptr();
 
       honey_mesh->calculate_initial_heights();
@@ -452,7 +452,7 @@ void Honeycomb::prepare_heights_calculation() {
 
   for (auto& row : _tiles_layout) {
     for (auto& tile_ptr : row) {
-      HoneycombTile* tile = dynamic_cast<HoneycombTile*>(tile_ptr.get());
+      HoneycombTile* tile = dynamic_cast<HoneycombTile*>(tile_ptr);
       HoneycombHoney* honey_mesh = tile->honey_mesh().ptr();
 
       honey_mesh->set_shift_compress(-global_min_y, compression_factor);
@@ -463,7 +463,7 @@ void Honeycomb::prepare_heights_calculation() {
 void Honeycomb::calculate_final_heights() {
   for (auto& row : _tiles_layout) {
     for (auto& tile_ptr : row) {
-      HoneycombTile* tile = dynamic_cast<HoneycombTile*>(tile_ptr.get());
+      HoneycombTile* tile = dynamic_cast<HoneycombTile*>(tile_ptr);
       HoneycombHoney* honey_mesh = tile->honey_mesh().ptr();
 
       honey_mesh->calculate_heights();
@@ -516,7 +516,7 @@ void HexagonalHoneycomb::_bind_methods() {
 Vector3 HexagonalHoneycomb::get_center() const {
   int total = 0;
   for (auto& row : _tiles_layout) {
-    for (auto& tile_ptr : row) {
+    for (auto* tile_ptr : row) {
       ++total;
     }
   }
@@ -525,7 +525,7 @@ Vector3 HexagonalHoneycomb::get_center() const {
   for (auto& row : _tiles_layout) {
     for (auto& tile_ptr : row) {
       if (i == middle) {
-        HoneycombTile* tile = dynamic_cast<HoneycombTile*>(tile_ptr.get());
+        HoneycombTile* tile = dynamic_cast<HoneycombTile*>(tile_ptr);
         HoneycombHoney* cell = tile->honey_mesh().ptr();
         return cell->get_center() + Vector3(0, 0, radius(diameter));  // + upper half of 0-row
       }

--- a/src/misc/tile.cpp
+++ b/src/misc/tile.cpp
@@ -3,6 +3,7 @@
 #include "cube_coordinates.h"
 #include "godot_cpp/classes/editor_interface.hpp"
 #include "godot_cpp/classes/engine.hpp"
+#include "godot_cpp/classes/mesh_instance3d.hpp"
 #include "godot_cpp/classes/sphere_shape3d.hpp"
 #include "godot_cpp/classes/static_body3d.hpp"
 #include "godot_cpp/core/memory.hpp"
@@ -17,9 +18,6 @@ using namespace gd;
 
 // Tile definitions
 Tile::~Tile() {}
-
-Tile::Tile(gd::Ref<HexMesh> mesh, OffsetCoordinates offset_coord)
-    : _mesh(mesh), offset_coord(offset_coord), shifted(is_odd(offset_coord.row)) {}
 
 Tile::Tile(gd::Ref<HexMesh> mesh, Vector3 offset, gd::Node3D* parent, OffsetCoordinates offset_coord)
     : _mesh(mesh), offset_coord(offset_coord), shifted(is_odd(offset_coord.row)) {
@@ -36,7 +34,9 @@ Tile::Tile(gd::Ref<HexMesh> mesh, Vector3 offset, gd::Node3D* parent, OffsetCoor
 
   _main_mesh_instance->set_mesh(mesh);
 
-  parent->add_child(_main_mesh_instance);
+  add_child(_main_mesh_instance);
+  parent->add_child(this);
+
   _main_mesh_instance->add_child(_static_body);
   _static_body->add_child(_collision_shape3d);
   if (Engine::get_singleton()->is_editor_hint()) {

--- a/src/misc/tile.h
+++ b/src/misc/tile.h
@@ -18,12 +18,11 @@
 
 namespace sota {
 
-class Tile {
+class Tile : public godot::Node3D {
  public:
   Tile() = delete;
   virtual ~Tile();
 
-  Tile(gd::Ref<HexMesh> mesh, OffsetCoordinates offset_coord);  // used by HexGridMap. Delete?
   Tile(gd::Ref<HexMesh> mesh, gd::Vector3 offset, gd::Node3D* parent, OffsetCoordinates offset_coord);
 
   gd::Ref<HexMesh> mesh() const;

--- a/src/ridge_impl/ridge_hex_grid_map.cpp
+++ b/src/ridge_impl/ridge_hex_grid_map.cpp
@@ -13,7 +13,6 @@
 #include "general_utility.h"
 #include "godot_cpp/classes/shader_material.hpp"
 #include "godot_cpp/variant/plane.hpp"
-#include "godot_cpp/variant/utility_functions.hpp"
 #include "godot_cpp/variant/vector3.hpp"
 #include "godot_cpp/variant/vector3i.hpp"
 #include "hexagonal_utility.h"
@@ -300,7 +299,7 @@ void RidgeHexGridMap::init_hexmesh() {
       };
       Ref<RidgeHexMesh> m = create_hex_mesh(biome, hex, params);
       _tiles_layout.back().push_back(
-          std::make_unique<BiomeTile>(m, this, biome, OffsetCoordinates{.row = val.x, .col = val.z}));
+          make_non_ref<BiomeTile>(m, this, biome, OffsetCoordinates{.row = val.x, .col = val.z}));
     }
   }
 }
@@ -367,7 +366,7 @@ void RidgeHexGridMap::calculate_neighbours(GroupOfHexagonMeshes& group) {
   };
   for (auto& row : _tiles_layout) {
     for (auto& tile_ptr : row) {
-      BiomeTile* tile = dynamic_cast<BiomeTile*>(tile_ptr.get());
+      BiomeTile* tile = dynamic_cast<BiomeTile*>(tile_ptr);
       RidgeHexMesh* mesh = dynamic_cast<RidgeHexMesh*>(tile->mesh().ptr());
       if (std::find(group.begin(), group.end(), mesh) == group.end()) {
         continue;
@@ -391,7 +390,7 @@ void RidgeHexGridMap::calculate_neighbours(GroupOfHexagonMeshes& group) {
 void RidgeHexGridMap::assign_neighbours(GroupOfHexagonMeshes& group) {
   for (auto& row : _tiles_layout) {
     for (auto& tile_ptr : row) {
-      BiomeTile* tile = dynamic_cast<BiomeTile*>(tile_ptr.get());
+      BiomeTile* tile = dynamic_cast<BiomeTile*>(tile_ptr);
       RidgeHexMesh* mesh = dynamic_cast<RidgeHexMesh*>(tile->mesh().ptr());
       if (std::find(group.begin(), group.end(), mesh) == group.end()) {
         continue;
@@ -517,7 +516,7 @@ void RidgeHexGridMap::prepare_heights_calculation() {
 void RidgeHexGridMap::assign_cube_coordinates_map() {
   for (auto& row : _tiles_layout) {
     for (auto& tile_ptr : row) {
-      BiomeTile* tile = dynamic_cast<BiomeTile*>(tile_ptr.get());
+      BiomeTile* tile = dynamic_cast<BiomeTile*>(tile_ptr);
       _cube_to_hexagon[tile->get_cube_coords()] = tile_ptr->mesh().ptr();
     }
   }
@@ -602,7 +601,7 @@ BiomeGroups RectRidgeHexGridMap::collect_biome_groups(Biome b) {
     for (Vector3i v : row) {
       int i = v.x;
       int j = v.z;
-      BiomeTile* tile = dynamic_cast<BiomeTile*>(_tiles_layout[i][j].get());
+      BiomeTile* tile = dynamic_cast<BiomeTile*>(_tiles_layout[i][j]);
       Biome biome = tile->biome();
       if (biome != b) {
         continue;
@@ -663,7 +662,7 @@ BiomeGroups HexagonalRidgeHexGridMap::collect_biome_groups(Biome b) {
   auto flat = [width](int i, int j) { return i * width + j; };
   for (auto& row : _tiles_layout) {
     for (auto& tile_ptr : row) {
-      BiomeTile* tile = dynamic_cast<BiomeTile*>(tile_ptr.get());
+      BiomeTile* tile = dynamic_cast<BiomeTile*>(tile_ptr);
       Biome biome = tile->biome();
       if (biome != b) {
         continue;


### PR DESCRIPTION
Because of inner logic of godot we can't rely on
destructors/constructors to manage liveness of objects: they obey rules
of `enter_tree` and `exit_tree`. If child/parent relations are mixed
with relations of aggregation(or composition) we may end up in situation
inside dtor of `grid` class when child objects are not destroyed and grid
object has no access to them via its children.

Cherry-picked from #22 