### PR TITLE
Instantiate objects via factory functions

### DIFF
--- a/project/demo_terrain/flat_terrain_scene.tscn
+++ b/project/demo_terrain/flat_terrain_scene.tscn
@@ -108,3 +108,5 @@ width = 7
 _shader = ExtResource("1_pum5v")
 enable_frame = true
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 8.30717, 0, 0)
+
+[node name="MeshInstance3D5" type="MeshInstance3D" parent="."]

--- a/register_types.cpp
+++ b/register_types.cpp
@@ -4,6 +4,7 @@
 #include "core/hex_mesh.h"
 #include "core/mesh.h"
 #include "core/pent_mesh.h"
+#include "godot_cpp/core/class_db.hpp"
 #include "honeycomb/honeycomb.h"
 #include "honeycomb/honeycomb_cell.h"
 #include "honeycomb/honeycomb_honey.h"
@@ -13,6 +14,16 @@
 #include "ridge_impl/ridge_hex_mesh.h"
 #include "src/tal/godot_core.h"
 
+/**
+ * @brief register classes used in editor
+ *
+ * @param p_level
+ *
+ * Some classes registered as abstract while they are not abstract in terms of C++. The reason to do it is to prohibit
+ * their instantiation outside of designed scope. For example, RidgeHexMesh class has meaning only if being used in
+ * RidgeHexGrid (and it's subclasses). If RidgeHexMesh is registered via GDREGISTER_CLASS it's open to instantiation
+ * e.g. in MeshInstance3D which makes no sence by design of RidgeHexGrid
+ */
 void initialize_Sota_module(ModuleInitializationLevel p_level) {
   if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
     return;
@@ -29,14 +40,14 @@ void initialize_Sota_module(ModuleInitializationLevel p_level) {
   GDREGISTER_CLASS(sota::HexagonalHexGrid);
 
   // Grids made of ridge hexes - hexes based on global graph of ridges
-  GDREGISTER_CLASS(sota::RidgeHexMesh);
+  GDREGISTER_ABSTRACT_CLASS(sota::RidgeHexMesh);  // NOT ABSTRACT, see comment to `initialize_Sota_module`
   GDREGISTER_ABSTRACT_CLASS(sota::RidgeHexGrid);
   GDREGISTER_CLASS(sota::RectRidgeHexGrid);
   GDREGISTER_CLASS(sota::HexagonalRidgeHexGrid);
 
   // Grids made of pairs of hexes
-  GDREGISTER_CLASS(sota::HoneycombCell);
-  GDREGISTER_CLASS(sota::HoneycombHoney);
+  GDREGISTER_ABSTRACT_CLASS(sota::HoneycombCell);   // NOT ABSTRACT, see comment to `initialize_Sota_module`
+  GDREGISTER_ABSTRACT_CLASS(sota::HoneycombHoney);  // NOT ABSTRACT, see comment to `initialize_Sota_module`
   GDREGISTER_ABSTRACT_CLASS(sota::Honeycomb);
   GDREGISTER_CLASS(sota::RectHoneycomb);
   GDREGISTER_CLASS(sota::HexagonalHoneycomb);

--- a/src/core/hex_mesh.h
+++ b/src/core/hex_mesh.h
@@ -33,6 +33,10 @@ class HexMesh : public SotaMesh {
   enum class TesselationType { Plane = 0, Polyhedron };
 
   HexMesh();
+  HexMesh(const HexMesh& other) = delete;
+  HexMesh(HexMesh&& other) = delete;
+  // copying operator= defined inside GDCLASS
+  HexMesh& operator=(HexMesh&& rhs) = delete;
 
   void set_diameter(const float p_diameter);
   float get_diameter() const;

--- a/src/core/pent_mesh.h
+++ b/src/core/pent_mesh.h
@@ -17,6 +17,10 @@ class PentMesh : public SotaMesh {
 
  public:
   PentMesh();
+  PentMesh(const PentMesh& other) = delete;
+  PentMesh(PentMesh&& other) = delete;
+  // copying operator= defined inside GDCLASS
+  PentMesh& operator=(PentMesh&& rhs) = delete;
 
   void init_impl() override;
   void update();

--- a/src/honeycomb/honeycomb_cell.cpp
+++ b/src/honeycomb/honeycomb_cell.cpp
@@ -11,6 +11,11 @@
 
 namespace sota {
 
+HoneycombCell::HoneycombCell(Hexagon hex, HoneycombCellMeshParams params) : HexMesh(hex, params.hex_mesh_params) {
+  _noise = params.noise;
+  _selection_material = params.selection_material;
+}
+
 void HoneycombCell::_bind_methods() {
   ClassDB::bind_method(D_METHOD("handle_mouse_entered"), &HoneycombCell::handle_mouse_entered);
   ClassDB::bind_method(D_METHOD("handle_mouse_exited"), &HoneycombCell::handle_mouse_exited);

--- a/src/honeycomb/honeycomb_cell.h
+++ b/src/honeycomb/honeycomb_cell.h
@@ -18,11 +18,11 @@ class HoneycombCell : public HexMesh {
   GDCLASS(HoneycombCell, HexMesh)
 
  public:
-  HoneycombCell() : HexMesh() {}
-  HoneycombCell(Hexagon hex, HoneycombCellMeshParams params) : HexMesh(hex, params.hex_mesh_params) {
-    _noise = params.noise;
-    _selection_material = params.selection_material;
-  }
+  HoneycombCell() = default;  // existence is 'must' for Godot
+  HoneycombCell(const HoneycombCell& other) = delete;
+  HoneycombCell(HoneycombCell&& other) = delete;
+  // copying operator= defined inside GDCLASS
+  HoneycombCell& operator=(HoneycombCell&& rhs) = delete;
 
   // getters
   GroupedHexagonMeshVertices get_grouped_vertices();
@@ -34,6 +34,7 @@ class HoneycombCell : public HexMesh {
   void calculate_heights(float bottom_offset);
 
  protected:
+  HoneycombCell(Hexagon hex, HoneycombCellMeshParams params);
   static void _bind_methods();
 
  private:
@@ -44,6 +45,8 @@ class HoneycombCell : public HexMesh {
   void handle_mouse_exited();
   void handle_input_event(Camera3D* p_camera, const Ref<InputEvent>& p_event, const Vector3& p_event_position,
                           const Vector3& p_normal, int32_t p_shape_idx);
+
+  friend Ref<HoneycombCell> make_honeycomb_cell(Hexagon hex, HoneycombCellMeshParams params);
 };
 
 Ref<HoneycombCell> make_honeycomb_cell(Hexagon hex, HoneycombCellMeshParams params);

--- a/src/honeycomb/honeycomb_honey.cpp
+++ b/src/honeycomb/honeycomb_honey.cpp
@@ -10,6 +10,13 @@
 
 namespace sota {
 
+HoneycombHoney::HoneycombHoney(Hexagon hex, HoneycombHoneyMeshParams params) : HexMesh(hex, params.hex_mesh_params) {
+  _noise = params.noise;
+  _max_level = params.max_level;
+  _fill_delta = params.fill_delta;
+  _min_offset = params.min_offset;
+}
+
 void HoneycombHoney::_bind_methods() {
   ClassDB::bind_method(D_METHOD("lock"), &HoneycombHoney::lock);
   ClassDB::bind_method(D_METHOD("unlock"), &HoneycombHoney::unlock);

--- a/src/honeycomb/honeycomb_honey.h
+++ b/src/honeycomb/honeycomb_honey.h
@@ -18,13 +18,11 @@ class HoneycombHoney : public HexMesh {
   GDCLASS(HoneycombHoney, HexMesh)
 
  public:
-  HoneycombHoney() : HexMesh(make_unit_hexagon()) {}
-  HoneycombHoney(Hexagon hex, HoneycombHoneyMeshParams params) : HexMesh(hex, params.hex_mesh_params) {
-    _noise = params.noise;
-    _max_level = params.max_level;
-    _fill_delta = params.fill_delta;
-    _min_offset = params.min_offset;
-  }
+  HoneycombHoney() = default;  // existence is 'must' for Godot
+  HoneycombHoney(const HoneycombHoney& other) = delete;
+  HoneycombHoney(HoneycombHoney&& other) = delete;
+  // copying operator= defined inside GDCLASS
+  HoneycombHoney& operator=(HoneycombHoney&& rhs) = delete;
 
   // getters
   GroupedHexagonMeshVertices get_grouped_vertices();
@@ -53,6 +51,7 @@ class HoneycombHoney : public HexMesh {
   bool is_empty() const;
 
  protected:
+  HoneycombHoney(Hexagon hex, HoneycombHoneyMeshParams params);
   static void _bind_methods();
 
  private:
@@ -69,6 +68,8 @@ class HoneycombHoney : public HexMesh {
   float _max_y = std::numeric_limits<float>::min();
   float _y_shift = 0.0f;     // no shift
   float _y_compress = 1.0f;  // no compress
+
+  friend Ref<HoneycombHoney> make_honeycomb_honey(Hexagon hex, HoneycombHoneyMeshParams params);
 };
 
 Ref<HoneycombHoney> make_honeycomb_honey(Hexagon hex, HoneycombHoneyMeshParams params);

--- a/src/misc/utilities.cpp
+++ b/src/misc/utilities.cpp
@@ -17,13 +17,13 @@ namespace sota {
 Ref<HexMesh> create_hex_mesh(Biome biome, Hexagon hex, RidgeHexMeshParams params) {
   switch (biome) {
     case Biome::MOUNTAIN:
-      return make_impl<MountainHexMesh>(hex, params);
+      return make_ridge_hex_mesh<MountainHexMesh>(hex, params);
     case Biome::PLAIN:
-      return make_impl<PlainHexMesh>(hex, params);
+      return make_ridge_hex_mesh<PlainHexMesh>(hex, params);
     case Biome::HILL:
-      return make_impl<HillHexMesh>(hex, params);
+      return make_ridge_hex_mesh<HillHexMesh>(hex, params);
     case Biome::WATER:
-      return make_impl<WaterHexMesh>(hex, params);
+      return make_ridge_hex_mesh<WaterHexMesh>(hex, params);
     default:
       printerr("Unreachable biome");
   }

--- a/src/misc/utilities.h
+++ b/src/misc/utilities.h
@@ -12,10 +12,4 @@ using PointDivisionedPosition = std::pair<int, int>;
 
 PointDivisionedPosition to_point_divisioned_position(Vector3 v, float diameter, int divisions);
 
-template <typename T>
-Ref<RidgeHexMesh> make_impl(Hexagon hex, RidgeHexMeshParams params) {
-  auto res = Ref<T>(memnew(T(hex, params)));
-  res->init();
-  return res;
-}
 }  // namespace sota

--- a/src/polyhedron/PolyhedronRidgeProcessor.cpp
+++ b/src/polyhedron/PolyhedronRidgeProcessor.cpp
@@ -50,7 +50,7 @@ void PolyhedronRidgeProcessor::configure_cell(Hexagon hex, Biome biome, int& id,
       .plain_noise = polyhedron_mesh._noise,
       .ridge_noise = nullptr,
   };
-  Ref<RidgeHexMesh> m = make_impl<PlainHexMesh>(hex, params);
+  Ref<RidgeHexMesh> m = make_ridge_hex_mesh<PlainHexMesh>(hex, params);
   m->set_tesselation_type(HexMesh::TesselationType::Polyhedron);
   // m->set_id(id);
 

--- a/src/prism_impl/prism_hex_mesh.h
+++ b/src/prism_impl/prism_hex_mesh.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "tal/wrapped.h"
 #include "hex_mesh.h"
+#include "tal/wrapped.h"
 #include "types.h"
 
 namespace sota {
@@ -9,7 +9,12 @@ namespace sota {
 class PrismHexMesh : public HexMesh {
   GDCLASS(PrismHexMesh, HexMesh)
  public:
-  PrismHexMesh() : HexMesh() {}
+  PrismHexMesh() = default;  // existence is 'must' for Godot
+  PrismHexMesh(const PrismHexMesh& other) = delete;
+  PrismHexMesh(PrismHexMesh&& other) = delete;
+  // copying operator= defined inside GDCLASS
+  PrismHexMesh& operator=(PrismHexMesh&& rhs) = delete;
+
   PrismHexMesh(Hexagon hex) : HexMesh(hex) {}
 
   void set_height(const float p_height);

--- a/src/ridge_impl/ridge_hex_mesh.h
+++ b/src/ridge_impl/ridge_hex_mesh.h
@@ -6,11 +6,11 @@
 #include <vector>
 
 #include "core/hex_mesh.h"
+#include "misc/types.h"
+#include "ridge_impl/ridge.h"
 #include "tal/noise.h"
 #include "tal/reference.h"
 #include "tal/vector3.h"
-#include "misc/types.h"
-#include "ridge_impl/ridge.h"
 
 namespace sota {
 
@@ -23,18 +23,11 @@ struct RidgeHexMeshParams {
 class RidgeHexMesh : public HexMesh {
   GDCLASS(RidgeHexMesh, HexMesh)
  public:
-  RidgeHexMesh() : HexMesh() {}
-  RidgeHexMesh(Hexagon hex, RidgeHexMeshParams params) : HexMesh(hex, params.hex_mesh_params) {
-    _id = params.hex_mesh_params.id;
-    _plain_noise = params.plain_noise;
-    _ridge_noise = params.ridge_noise;
-    _diameter = params.hex_mesh_params.diameter;
-    _frame_state = params.hex_mesh_params.frame_state;
-    _frame_offset = params.hex_mesh_params.frame_offset;
-    _divisions = params.hex_mesh_params.divisions;
-    set_material(params.hex_mesh_params.material);
-    _clip_options = params.hex_mesh_params.clip_options;
-  }
+  RidgeHexMesh() = default;  // existence is 'must' for Godot
+  RidgeHexMesh(const RidgeHexMesh& other) = delete;
+  RidgeHexMesh(RidgeHexMesh&& other) = delete;
+  // copying operator= defined inside GDCLASS
+  RidgeHexMesh& operator=(RidgeHexMesh&& rhs) = delete;
 
   // getters
   std::vector<HexMesh*> get_neighbours() const;
@@ -55,6 +48,17 @@ class RidgeHexMesh : public HexMesh {
   virtual void calculate_final_heights() {}
 
  protected:
+  RidgeHexMesh(Hexagon hex, RidgeHexMeshParams params) : HexMesh(hex, params.hex_mesh_params) {
+    _id = params.hex_mesh_params.id;
+    _plain_noise = params.plain_noise;
+    _ridge_noise = params.ridge_noise;
+    _diameter = params.hex_mesh_params.diameter;
+    _frame_state = params.hex_mesh_params.frame_state;
+    _frame_offset = params.hex_mesh_params.frame_offset;
+    _divisions = params.hex_mesh_params.divisions;
+    set_material(params.hex_mesh_params.material);
+    _clip_options = params.hex_mesh_params.clip_options;
+  }
   static void _bind_methods();
 
   Vector3Array _initial_vertices;
@@ -76,5 +80,12 @@ class RidgeHexMesh : public HexMesh {
  private:
   std::map<Vector3, float> _corner_points_to_border_dist;
 };
+
+template <typename T>
+Ref<RidgeHexMesh> make_ridge_hex_mesh(Hexagon hex, RidgeHexMeshParams params) {
+  auto res = Ref<T>(memnew(T(hex, params)));
+  res->init();
+  return res;
+}
 
 }  // namespace sota


### PR DESCRIPTION
Factory functions encapsulate construction of objects. For example, some objects have to set multiple parameters before (re)initialization.

Exclusion is made only for default constructors: if we have Class A, then there must be public constructor which takes no arguments, otherwise we can't compile godot's code