### PR TITLE
Unify construction of hex faces

### DIFF
--- a/project/demo_terrain/flat_terrain_scene.tscn
+++ b/project/demo_terrain/flat_terrain_scene.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=20 format=3 uid="uid://c7u64tpv6byvb"]
+[gd_scene load_steps=22 format=3 uid="uid://c7u64tpv6byvb"]
 
 [ext_resource type="Shader" path="res://demo_terrain/shaders/wireframe.gdshader" id="1_pum5v"]
 [ext_resource type="Texture2D" uid="uid://cdx7ceoux78g0" path="res://demo_terrain/textures/yellow_grass.png" id="2_diq8e"]
@@ -41,6 +41,15 @@ shader = ExtResource("1_pum5v")
 [sub_resource type="HexMesh" id="HexMesh_i6ufk"]
 divisions = 2
 material = SubResource("ShaderMaterial_djkpx")
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_g7q1k"]
+render_priority = 0
+shader = ExtResource("1_pum5v")
+
+[sub_resource type="PrismHexMesh" id="PrismHexMesh_cf0jy"]
+height = 0.75
+divisions = 2
+material = SubResource("ShaderMaterial_g7q1k")
 
 [node name="Node3D" type="Node3D"]
 
@@ -94,7 +103,7 @@ _height = 1
 width = 1
 _shader = ExtResource("1_pum5v")
 enable_frame = true
-_frame_offset = 0.205
+_frame_offset = 0.545
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -3.76043, -9.53674e-07, 3.01861)
 
 [node name="HexagonalHexGrid" type="HexagonalHexGrid" parent="."]
@@ -109,4 +118,6 @@ _shader = ExtResource("1_pum5v")
 enable_frame = true
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 8.30717, 0, 0)
 
-[node name="MeshInstance3D5" type="MeshInstance3D" parent="."]
+[node name="MeshInstance3D2" type="MeshInstance3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 6.96372, 0, 6.61693)
+mesh = SubResource("PrismHexMesh_cf0jy")

--- a/src/core/hex_grid.cpp
+++ b/src/core/hex_grid.cpp
@@ -3,6 +3,10 @@
 #include "core/hex_mesh.h"
 #include "core/utils.h"
 #include "cube_coordinates.h"
+#include "godot_utils.h"
+#include "hexagonal_utility.h"
+#include "primitives/Hexagon.h"
+#include "rectangular_utility.h"
 #include "tal/arrays.h"
 #include "tal/godot_core.h"
 #include "tal/object.h"
@@ -12,10 +16,6 @@
 #include "tal/vector3.h"
 #include "tal/vector3i.h"
 #include "tal/wrapped.h"
-#include "godot_utils.h"
-#include "hexagonal_utility.h"
-#include "primitives/Hexagon.h"
-#include "rectangular_utility.h"
 #include "types.h"
 
 namespace sota {
@@ -76,7 +76,7 @@ void HexGrid::set_frame_state(const bool p_state) {
 }
 
 void HexGrid::set_frame_offset(const float p_offset) {
-  _frame_offset = p_offset;
+  _frame_offset = p_offset > 0 ? p_offset : 0;
   init();
 }
 

--- a/src/core/hex_mesh.cpp
+++ b/src/core/hex_mesh.cpp
@@ -34,6 +34,8 @@ HexMesh::HexMesh(Hexagon hex, HexMeshParams params) {
   set_material(params.material);
   _divisions = params.divisions;
   _clip_options = params.clip_options;
+  _tesselation_mode = params.tesselation_mode;
+  _tesselation_type = params.tesselation_type;
 }
 
 HexMesh::HexMesh(Hexagon hex) {
@@ -49,15 +51,17 @@ HexMesh::HexMesh(Hexagon hex) {
   set_material(params.material);
   _divisions = params.divisions;
   _clip_options = params.clip_options;
+  _tesselation_mode = params.tesselation_mode;
+  _tesselation_type = params.tesselation_type;
 }
 
 void HexMesh::init_impl() {
-  if (tesselation_mode == TesselationMode::Iterative) {
+  if (_tesselation_mode == TesselationMode::Iterative) {
     calculate_vertices_iteration();
     if (_frame_state) {
       add_frame();
     }
-  } else if (tesselation_mode == TesselationMode::Recursive) {
+  } else if (_tesselation_mode == TesselationMode::Recursive) {
     calculate_vertices_recursion();
   }
   recalculate_all_except_vertices();
@@ -249,7 +253,7 @@ void HexMesh::calculate_tex_uv1() {
   float r = small_radius(diameter);
   Vector3 direction0 = (corner_points[3] - corner_points[0]).normalized();
   Vector3 direction1 =
-      tesselation_type == TesselationType::Plane ? direction0.cross(normal) : direction0.cross(c.normalized());
+      _tesselation_type == TesselationType::Plane ? direction0.cross(normal) : direction0.cross(c.normalized());
 
   Vector3 p0 = c - direction1 * r - direction0 * R;
   Vector3 p1 = c - direction1 * r + direction0 * R;

--- a/src/core/hex_mesh.h
+++ b/src/core/hex_mesh.h
@@ -12,6 +12,7 @@
 namespace sota {
 
 enum class TesselationMode { Iterative = 0, Recursive };
+enum class TesselationType { Plane = 0, Polyhedron };
 
 struct HexMeshParams {
   int id{0};
@@ -24,14 +25,15 @@ struct HexMeshParams {
   Ref<Material> material;
   int divisions{3};
   ClipOptions clip_options;
+
+  TesselationMode tesselation_mode{TesselationMode::Iterative};
+  TesselationType tesselation_type{TesselationType::Plane};
 };
 
 class HexMesh : public SotaMesh {
   GDCLASS(HexMesh, SotaMesh)
 
  public:
-  enum class TesselationType { Plane = 0, Polyhedron };
-
   HexMesh();
   HexMesh(const HexMesh& other) = delete;
   HexMesh(HexMesh&& other) = delete;
@@ -47,9 +49,9 @@ class HexMesh : public SotaMesh {
   void set_frame_state(bool state) { _frame_state = state; }
   void set_frame_value(float value) { _frame_offset = value; }
 
-  void set_tesselation_type(TesselationType p_tesselation_type) { tesselation_type = p_tesselation_type; }
+  void set_tesselation_type(TesselationType p_tesselation_type) { _tesselation_type = p_tesselation_type; }
   void set_clip_options(ClipOptions p_options) { _clip_options = p_options; }
-  void set_tesselation_mode(TesselationMode p_tesselation_mode) { tesselation_mode = p_tesselation_mode; }
+  void set_tesselation_mode(TesselationMode p_tesselation_mode) { _tesselation_mode = p_tesselation_mode; }
 
  protected:
   HexMesh(Hexagon hex, HexMeshParams params);
@@ -64,8 +66,8 @@ class HexMesh : public SotaMesh {
   float _r;
   float _diameter{1};
   Hexagon _hex = make_unit_hexagon();
-  TesselationType tesselation_type{TesselationType::Plane};
-  TesselationMode tesselation_mode{TesselationMode::Iterative};
+  TesselationType _tesselation_type{TesselationType::Plane};
+  TesselationMode _tesselation_mode{TesselationMode::Iterative};
 
   bool _frame_state{false};
   float _frame_offset{0.0};

--- a/src/polyhedron/PolyhedronPrismProcessor.cpp
+++ b/src/polyhedron/PolyhedronPrismProcessor.cpp
@@ -16,7 +16,7 @@ void PolyhedronPrismProcessor::configure_cell(Hexagon hex, Biome biome, int& id,
                                                              .divisions = polyhedron_mesh._divisions,
                                                              .clip_options = ClipOptions(),
                                                              .tesselation_mode = TesselationMode::Recursive,
-                                                             .tesselation_type = TesselationType::Polyhedron},
+                                                             .tesselation_type = Orientation::Polyhedron},
                             .height = polyhedron_mesh._prism_heights[biome]};
   Ref<PrismHexMesh> m = make_prism_mesh(hex, params);
 

--- a/src/polyhedron/PolyhedronPrismProcessor.cpp
+++ b/src/polyhedron/PolyhedronPrismProcessor.cpp
@@ -1,23 +1,24 @@
 #include "polyhedron/PolyhedronPrismProcessor.h"
 
+#include "hex_mesh.h"
 #include "polyhedron/hex_polyhedron.h"
 #include "prism_hex_mesh.h"
 #include "tal/mesh.h"
 #include "tal/reference.h"
+#include "types.h"
 
 namespace sota {
 
 void PolyhedronPrismProcessor::configure_cell(Hexagon hex, Biome biome, int& id, Ref<ShaderMaterial> mat,
                                               PolyhedronMesh& polyhedron_mesh) {
-  Ref<PrismHexMesh> m(memnew(PrismHexMesh(hex)));
-  m->set_height(polyhedron_mesh._prism_heights[biome]);
-  m->set_tesselation_type(HexMesh::TesselationType::Polyhedron);
-  m->set_id(id);
-
-  m->set_divisions(polyhedron_mesh._divisions);
-  m->set_material(mat);
-  m->set_tesselation_mode(TesselationMode::Recursive);
-  m->init();
+  PrismHexMeshParams params{.hex_mesh_params = HexMeshParams{.id = id,
+                                                             .material = mat,
+                                                             .divisions = polyhedron_mesh._divisions,
+                                                             .clip_options = ClipOptions(),
+                                                             .tesselation_mode = TesselationMode::Recursive,
+                                                             .tesselation_type = TesselationType::Polyhedron},
+                            .height = polyhedron_mesh._prism_heights[biome]};
+  Ref<PrismHexMesh> m = make_prism_mesh(hex, params);
 
   auto* mi = memnew(MeshInstance3D());
   mi->set_mesh(m);

--- a/src/polyhedron/PolyhedronRidgeProcessor.cpp
+++ b/src/polyhedron/PolyhedronRidgeProcessor.cpp
@@ -51,7 +51,7 @@ void PolyhedronRidgeProcessor::configure_cell(Hexagon hex, Biome biome, int& id,
       .ridge_noise = nullptr,
   };
   Ref<RidgeHexMesh> m = make_ridge_hex_mesh<PlainHexMesh>(hex, params);
-  m->set_tesselation_type(HexMesh::TesselationType::Polyhedron);
+  m->set_tesselation_type(TesselationType::Polyhedron);
   // m->set_id(id);
 
   // m->set_divisions(divisions);

--- a/src/polyhedron/PolyhedronRidgeProcessor.cpp
+++ b/src/polyhedron/PolyhedronRidgeProcessor.cpp
@@ -51,7 +51,7 @@ void PolyhedronRidgeProcessor::configure_cell(Hexagon hex, Biome biome, int& id,
       .ridge_noise = nullptr,
   };
   Ref<RidgeHexMesh> m = make_ridge_hex_mesh<PlainHexMesh>(hex, params);
-  m->set_tesselation_type(TesselationType::Polyhedron);
+  m->set_tesselation_type(Orientation::Polyhedron);
   // m->set_id(id);
 
   // m->set_divisions(divisions);

--- a/src/primitives/Edge.h
+++ b/src/primitives/Edge.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "tal//vector3.h"
+
+namespace sota {
+
+struct Edge {
+  Vector3 a;
+  Vector3 b;
+};
+
+}  // namespace sota

--- a/src/primitives/Face.h
+++ b/src/primitives/Face.h
@@ -1,0 +1,21 @@
+#pragma once
+#include "primitives/Edge.h"
+#include "primitives/Triangle.h"
+
+namespace sota {
+
+class Face {
+ public:
+  Face(Edge f, Edge s) {
+    first = Triangle{.a = f.a, .b = f.b, .c = s.a};
+    second = Triangle{.a = s.a, .b = f.b, .c = s.b};
+  }
+
+  std::pair<Triangle, Triangle> get_triangles() { return {first, second}; }
+
+ private:
+  Triangle first;
+  Triangle second;
+};
+
+}  // namespace sota

--- a/src/primitives/Triangle.h
+++ b/src/primitives/Triangle.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "tal/arrays.h"
+#include "tal/vector3.h"
+
+namespace sota {
+
+struct Triangle {
+  Vector3 a;
+  Vector3 b;
+  Vector3 c;
+
+  Vector3Array to_godot_array() const { return Vector3Array{a, b, c}; }
+};
+
+}  // namespace sota

--- a/src/prism_impl/prism_hex_mesh.cpp
+++ b/src/prism_impl/prism_hex_mesh.cpp
@@ -1,9 +1,13 @@
 #include "prism_impl/prism_hex_mesh.h"
 
-#include "tal/godot_core.h"
+#include "godot_cpp/core/memory.hpp"
 #include "misc/types.h"
+#include "tal/godot_core.h"
 
 namespace sota {
+PrismHexMesh::PrismHexMesh(Hexagon hex, PrismHexMeshParams params) : HexMesh(hex, params.hex_mesh_params) {
+  _height = params.height;
+}
 
 void PrismHexMesh::_bind_methods() {
   ClassDB::bind_method(D_METHOD("get_height"), &PrismHexMesh::get_height);
@@ -40,6 +44,12 @@ void PrismHexMesh::calculate_heights() {
     vertices_.push_back(b);
     vertices_.push_back(d);
   }
+}
+
+Ref<PrismHexMesh> make_prism_mesh(Hexagon hex, PrismHexMeshParams params) {
+  auto res = Ref<PrismHexMesh>(memnew(PrismHexMesh(hex, params)));
+  res->init();
+  return res;
 }
 
 }  // namespace sota

--- a/src/prism_impl/prism_hex_mesh.cpp
+++ b/src/prism_impl/prism_hex_mesh.cpp
@@ -3,6 +3,7 @@
 #include "godot_cpp/core/memory.hpp"
 #include "hex_mesh.h"
 #include "misc/types.h"
+#include "primitives/Triangle.h"
 #include "tal/godot_core.h"
 
 namespace sota {
@@ -17,6 +18,9 @@ void PrismHexMesh::_bind_methods() {
 }
 
 void PrismHexMesh::set_height(const float p_height) {
+  if (p_height < 0) {
+    return;
+  }
   _height = p_height;
   init();
   calculate_heights();
@@ -28,9 +32,9 @@ float PrismHexMesh::get_height() const { return _height; }
 
 void PrismHexMesh::calculate_heights() {
   for (auto& v : vertices_) {
-    if (_tesselation_type == TesselationType::Polyhedron) {
+    if (_tesselation_type == Orientation::Polyhedron) {
       v += v.normalized() * _height;
-    } else if (_tesselation_type == TesselationType::Plane) {
+    } else if (_tesselation_type == Orientation::Plane) {
       v += _hex.normal() * _height;
     }
   }
@@ -38,22 +42,7 @@ void PrismHexMesh::calculate_heights() {
   for (int i = 0; i < 6; ++i) {
     auto corner_points = _hex.points();
 
-    auto a = corner_points[i];
-    auto b = corner_points[(i + 1) % 6];
-
-    auto a_normal = _tesselation_type == TesselationType::Plane ? _hex.normal() : a.normalized();
-    auto c = a + a_normal * _height;
-
-    auto b_normal = _tesselation_type == TesselationType::Plane ? _hex.normal() : b.normalized();
-    auto d = b + b_normal * _height;
-
-    vertices_.push_back(a);
-    vertices_.push_back(b);
-    vertices_.push_back(c);
-
-    vertices_.push_back(c);
-    vertices_.push_back(b);
-    vertices_.push_back(d);
+    add_face_to_base_hex(Edge{.a = corner_points[i], .b = corner_points[(i + 1) % 6]}, _height);
   }
 }
 

--- a/src/prism_impl/prism_hex_mesh.h
+++ b/src/prism_impl/prism_hex_mesh.h
@@ -6,6 +6,11 @@
 
 namespace sota {
 
+struct PrismHexMeshParams {
+  HexMeshParams hex_mesh_params;
+  float height{0.0};
+};
+
 class PrismHexMesh : public HexMesh {
   GDCLASS(PrismHexMesh, HexMesh)
  public:
@@ -15,18 +20,21 @@ class PrismHexMesh : public HexMesh {
   // copying operator= defined inside GDCLASS
   PrismHexMesh& operator=(PrismHexMesh&& rhs) = delete;
 
-  PrismHexMesh(Hexagon hex) : HexMesh(hex) {}
-
   void set_height(const float p_height);
   float get_height() const;
 
   void calculate_heights();
 
  protected:
+  PrismHexMesh(Hexagon hex, PrismHexMeshParams params);
   static void _bind_methods();
 
  private:
   float _height{0.0};
+
+  friend Ref<PrismHexMesh> make_prism_mesh(Hexagon hex, PrismHexMeshParams params);
 };
+
+Ref<PrismHexMesh> make_prism_mesh(Hexagon hex, PrismHexMeshParams params);
 
 }  // namespace sota

--- a/src/ridge_impl/ridge_hex_mesh.cpp
+++ b/src/ridge_impl/ridge_hex_mesh.cpp
@@ -68,9 +68,9 @@ void RidgeHexMesh::calculate_corner_points_distances_to_border() {
 void RidgeHexMesh::shift_compress() {
   auto center = _hex.center();
 
-  if (_tesselation_type == TesselationType::Plane) {
+  if (_tesselation_type == Orientation::Plane) {
     GeneralUtility::shift_compress(vertices_, _y_shift, _y_compress, center.y);
-  } else if (_tesselation_type == TesselationType::Polyhedron) {
+  } else if (_tesselation_type == Orientation::Polyhedron) {
     vertices_ =
         GeneralUtility::shift_compress_polyhedron(vertices_, _initial_vertices, _y_shift, _y_compress, center.y);
   } else {
@@ -160,14 +160,14 @@ void RidgeHexMesh::calculate_ridge_based_heights(std::function<double(double, do
 void RidgeHexMesh::calculate_initial_heights() {
   auto normal = _hex.normal();
 
-  if (_tesselation_type == TesselationType::Plane) {
+  if (_tesselation_type == Orientation::Plane) {
     for (auto& v : vertices_) {
       float n = _plain_noise.ptr() ? _plain_noise->get_noise_2d(v.x, v.z) : 0.0;
       v += n * normal;
       _min_y = std::min(_min_y, v.y);
       _max_y = std::max(_max_y, v.y);
     }
-  } else if (_tesselation_type == TesselationType::Polyhedron) {
+  } else if (_tesselation_type == Orientation::Polyhedron) {
     _initial_vertices = vertices_;
     for (auto& v : vertices_) {
       float n = _plain_noise.ptr() ? _plain_noise->get_noise_3d(v.x, v.y, v.z) : 0.0;

--- a/src/ridge_impl/ridge_hex_mesh.cpp
+++ b/src/ridge_impl/ridge_hex_mesh.cpp
@@ -68,9 +68,9 @@ void RidgeHexMesh::calculate_corner_points_distances_to_border() {
 void RidgeHexMesh::shift_compress() {
   auto center = _hex.center();
 
-  if (tesselation_type == HexMesh::TesselationType::Plane) {
+  if (_tesselation_type == TesselationType::Plane) {
     GeneralUtility::shift_compress(vertices_, _y_shift, _y_compress, center.y);
-  } else if (tesselation_type == TesselationType::Polyhedron) {
+  } else if (_tesselation_type == TesselationType::Polyhedron) {
     vertices_ =
         GeneralUtility::shift_compress_polyhedron(vertices_, _initial_vertices, _y_shift, _y_compress, center.y);
   } else {
@@ -160,14 +160,14 @@ void RidgeHexMesh::calculate_ridge_based_heights(std::function<double(double, do
 void RidgeHexMesh::calculate_initial_heights() {
   auto normal = _hex.normal();
 
-  if (tesselation_type == HexMesh::TesselationType::Plane) {
+  if (_tesselation_type == TesselationType::Plane) {
     for (auto& v : vertices_) {
       float n = _plain_noise.ptr() ? _plain_noise->get_noise_2d(v.x, v.z) : 0.0;
       v += n * normal;
       _min_y = std::min(_min_y, v.y);
       _max_y = std::max(_max_y, v.y);
     }
-  } else if (tesselation_type == HexMesh::TesselationType::Polyhedron) {
+  } else if (_tesselation_type == TesselationType::Polyhedron) {
     _initial_vertices = vertices_;
     for (auto& v : vertices_) {
       float n = _plain_noise.ptr() ? _plain_noise->get_noise_3d(v.x, v.y, v.z) : 0.0;


### PR DESCRIPTION
#### Unify construction of faces for HexMesh and Prism

'Frame' is additional faces for HexMesh going downward, and Prism has
additional faces which goes upward. Factor out commond code, add trivial
classes: Triangle, Edge, Face

#### Fix calculation of PrismHexMesh's height

Previously it was calculated correctly only for polyhedron

#### Add function for PrismHexMesh construction

Missed previously

Resolves: #18 