### PR TITLE
Fix includes and std for module build and add MSVC support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .scons-cache/
 *.os
 *.o
+*.obj
 
 # SConstruct
 .sconf_temp

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -5,3 +5,5 @@
 Roman Ardazishvili
 
 ## Developers
+
+[HKunogi](https://github.com/HKunogi)

--- a/SCsub
+++ b/SCsub
@@ -1,22 +1,34 @@
 #!/usr/bin/env python
 
 Import('env')
+Import('env_modules')
 
-env = env.Clone()
+env_sota = env_modules.Clone()
 
-env.Append(CXXFLAGS=["-std=c++20", "-g"])
-env.Append(CPPDEFINES=["SOTA_MODULE"])
+if not env.msvc:
+    CXXFLAGS=['-std=c++20']
+    env_sota['CXXFLAGS'].remove('-std=gnu++17')
+else:
+    CXXFLAGS=['/std:c++20']
+    env_sota['CCFLAGS'].remove('/std:c++17')
+    env_sota.Append(CPPDEFINES=["MSVC"])
 
-env.Append(CPPPATH=["src"])
-env.Append(CPPPATH=["src/tal"])
-env.Append(CPPPATH=["src/polyhedron"])
-env.Append(CPPPATH=["src/primitives"])
-env.Append(CPPPATH=["src/core"])
-env.Append(CPPPATH=["src/prism_impl"])
-env.Append(CPPPATH=["src/ridge_impl"])
-env.Append(CPPPATH=["src/honeycomb"])
-env.Append(CPPPATH=["src/misc"])
-env.Append(CPPPATH=["src/algo"])
+env_sota.Append(CXXFLAGS=CXXFLAGS)
+
+Export('env_sota')
+
+env_sota.Append(CPPDEFINES=["SOTA_MODULE"])
+
+env_sota.Append(CPPPATH=["src"])
+env_sota.Append(CPPPATH=["src/tal"])
+env_sota.Append(CPPPATH=["src/polyhedron"])
+env_sota.Append(CPPPATH=["src/primitives"])
+env_sota.Append(CPPPATH=["src/core"])
+env_sota.Append(CPPPATH=["src/prism_impl"])
+env_sota.Append(CPPPATH=["src/ridge_impl"])
+env_sota.Append(CPPPATH=["src/honeycomb"])
+env_sota.Append(CPPPATH=["src/misc"])
+env_sota.Append(CPPPATH=["src/algo"])
 
 sources = Glob("register_types.cpp")
 sources += Glob("src/*.cpp")
@@ -29,4 +41,4 @@ sources += Glob("src/honeycomb/*.cpp")
 sources += Glob("src/misc/*.cpp")
 sources += Glob("src/algo/*.cpp")
 
-env.add_source_files(env.modules_sources, sources)
+env_sota.add_source_files(env.modules_sources, sources)

--- a/register_types.cpp
+++ b/register_types.cpp
@@ -4,7 +4,11 @@
 #include "core/hex_mesh.h"
 #include "core/mesh.h"
 #include "core/pent_mesh.h"
+#if SOTA_MODULE
+#include "core/object/class_db.h"
+#else
 #include "godot_cpp/core/class_db.hpp"
+#endif
 #include "honeycomb/honeycomb.h"
 #include "honeycomb/honeycomb_cell.h"
 #include "honeycomb/honeycomb_honey.h"

--- a/register_types.cpp
+++ b/register_types.cpp
@@ -4,11 +4,6 @@
 #include "core/hex_mesh.h"
 #include "core/mesh.h"
 #include "core/pent_mesh.h"
-#if SOTA_MODULE
-#include "core/object/class_db.h"
-#else
-#include "godot_cpp/core/class_db.hpp"
-#endif
 #include "honeycomb/honeycomb.h"
 #include "honeycomb/honeycomb_cell.h"
 #include "honeycomb/honeycomb_honey.h"

--- a/src/honeycomb/honeycomb.cpp
+++ b/src/honeycomb/honeycomb.cpp
@@ -1,7 +1,5 @@
 #include "honeycomb.h"
 
-#include <unistd.h>
-
 #include <algorithm>
 #include <memory>
 #include <random>

--- a/src/misc/types.h
+++ b/src/misc/types.h
@@ -3,6 +3,9 @@
 #include <array>
 #include <map>
 #include <vector>
+#include <unordered_map>
+#include <iterator>
+#include <algorithm>
 
 #include "tal/vector3.h"
 

--- a/src/primitives/Polygon.h
+++ b/src/primitives/Polygon.h
@@ -1,7 +1,8 @@
 #pragma once
 
 #include <vector>
-
+#include <algorithm>
+#include <cmath>
 #include "tal/vector3.h"
 
 namespace sota {

--- a/src/prism_impl/prism_hex_mesh.cpp
+++ b/src/prism_impl/prism_hex_mesh.cpp
@@ -1,10 +1,5 @@
 #include "prism_impl/prism_hex_mesh.h"
 
-#if SOTA_MODULE
-#include "core/os/memory.h"
-#else
-#include "godot_cpp/core/memory.hpp"
-#endif
 #include "hex_mesh.h"
 #include "misc/types.h"
 #include "primitives/Triangle.h"

--- a/src/prism_impl/prism_hex_mesh.cpp
+++ b/src/prism_impl/prism_hex_mesh.cpp
@@ -1,6 +1,10 @@
 #include "prism_impl/prism_hex_mesh.h"
 
+#if SOTA_MODULE
+#include "core/os/memory.h"
+#else
 #include "godot_cpp/core/memory.hpp"
+#endif
 #include "hex_mesh.h"
 #include "misc/types.h"
 #include "primitives/Triangle.h"

--- a/src/tal/godot_core.h
+++ b/src/tal/godot_core.h
@@ -11,6 +11,7 @@
 #include "godot_cpp/godot.hpp"
 #include "godot_cpp/variant/utility_functions.hpp"
 #include "godot_cpp/variant/variant.hpp"
+#include "godot_cpp/core/memory.hpp"
 
 using ClassDB = godot::ClassDB;
 using UtilityFunctions = godot::UtilityFunctions;
@@ -39,6 +40,8 @@ auto printerr(Args&&... args) -> decltype(UtilityFunctions::print(std::forward<A
 
 #else
 
+#include "core/object/class_db.h"
+#include "core/os/memory.h"
 #include "core/string/print_string.h"
 #include "core/variant/variant_utility.h"
 #include "editor/editor_interface.h"


### PR DESCRIPTION
With this commit I could successfully build it as a module on the editor for windows with C# support using latest godot engine 4.4 source code by simply cloning the repository under the modules folder.
![image](https://github.com/user-attachments/assets/bd55e060-0982-4d53-9788-e4538dfc2d03)
![image](https://github.com/user-attachments/assets/c677f0f8-be12-4647-a5b1-5ca7708f906b)