### PR TITLE
Add editor check for extension version and update module C++ flags replacement

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -39,6 +39,10 @@ addon_path = Path(extension_path).parent
 project_name = Path(extension_path).stem
 
 debug_or_release = "release" if env["target"] == "template_release" else "debug"
+
+if env["target"] == "editor":
+    env_sota.Append(CPPDEFINES=["SOTA_ENGINE"])
+
 if env["platform"] == "macos":
     library = env.SharedLibrary(
         "{0}/bin/lib{1}.{2}.{3}.framework/{1}.{2}.{3}".format(

--- a/SCsub
+++ b/SCsub
@@ -7,7 +7,7 @@ env_sota = env_modules.Clone()
 
 if env.msvc:
     CXXFLAGS=['/std:c++20']
-    env_sota['CCFLAGS'].remove('/std:c++17')
+    env_sota['CXXFLAGS'].remove('/std:c++17')
     env_sota.Append(CPPDEFINES=["MSVC"])
 else:
     CXXFLAGS=['-std=c++20']


### PR DESCRIPTION
After the [commit ](https://github.com/godotengine/godot/commit/d6c0509b5a7f746b06d06b03b1bce10fcd7a047c) on godot engine they changed how the compiler is detected and changed where the C++ flags are defined, this update the SCSub to keep on track with it. Also adds the SOTA_ENGINE define on the editor build case for the extension build method.
Also for preview visual studio versions gotta wait [this issue](https://github.com/godotengine/godot/issues/97619) to get solved to allow for the build, which should be done soon.