### PR TITLE
Cleanup includes

### DIFF
--- a/src/core/general_utility.cpp
+++ b/src/core/general_utility.cpp
@@ -1,16 +1,18 @@
 #include "core/general_utility.h"
 
-#include <cstdlib>
-#include <functional>
+#include <cmath>       // for lerp
+#include <functional>  // for function
 
-#include "misc/types.h"
-#include "misc/utilities.h"
-#include "primitives/polygon.h"
-#include "tal/arrays.h"
-#include "tal/godot_core.h"
-#include "tal/noise.h"
-#include "tal/vector2.h"
-#include "tal/vector3.h"
+#include "core/utils.h"          // for epsilonEqual
+#include "misc/types.h"          // for GroupedMeshVer...
+#include "misc/utilities.h"      // for to_point_divis...
+#include "primitives/polygon.h"  // for RegularPolygon
+#include "ridge_impl/ridge.h"    // for Ridge
+#include "tal/arrays.h"          // for Vector3Array
+#include "tal/noise.h"           // for FastNoiseLite
+#include "tal/reference.h"       // for Ref
+#include "tal/vector2.h"         // for Vector2
+#include "tal/vector3.h"         // for Vector3
 
 namespace sota {
 

--- a/src/core/general_utility.h
+++ b/src/core/general_utility.h
@@ -1,17 +1,26 @@
 #pragma once
 
-#include <set>
-#include <vector>
-#include <functional>
+#include <algorithm>   // for min
+#include <array>       // for array
+#include <cmath>       // for abs
+#include <functional>  // for function
+#include <limits>      // for numeric_limits
+#include <map>         // for map
+#include <set>         // for set
+#include <utility>     // for pair
+#include <vector>      // for vector
 
-#include "misc/types.h"
-#include "noise.h"
+#include "misc/types.h"  // for GroupedMeshVertices
 #include "primitives/polygon.h"
 #include "ridge_impl/ridge.h"
-#include "tal/arrays.h"
-#include "tal/reference.h"
-#include "tal/vector3.h"
+#include "tal/arrays.h"     // for Vector3Array
+#include "tal/noise.h"      // for FastNoiseLite
+#include "tal/reference.h"  // for Ref
+#include "tal/vector3.h"    // for Vector3
+
 namespace sota {
+class RegularPolygon;
+class Ridge;
 
 class MeshProcessor {
  public:

--- a/src/core/godot_utils.cpp
+++ b/src/core/godot_utils.cpp
@@ -1,7 +1,8 @@
 #include "core/godot_utils.h"
 
-#include "tal/arrays.h"
-#include "tal/object.h"
+#include "tal/arrays.h"  // for TypedArray
+#include "tal/node.h"    // for Node, Node3D
+#include "tal/object.h"  // for Object
 
 namespace sota {
 

--- a/src/core/hex_grid.cpp
+++ b/src/core/hex_grid.cpp
@@ -1,22 +1,25 @@
 #include "core/hex_grid.h"
 
-#include "core/hex_mesh.h"
-#include "core/utils.h"
-#include "cube_coordinates.h"
-#include "godot_utils.h"
-#include "hexagonal_utility.h"
-#include "primitives/hexagon.h"
-#include "rectangular_utility.h"
-#include "tal/arrays.h"
-#include "tal/godot_core.h"
-#include "tal/object.h"
-#include "tal/reference.h"
-#include "tal/shader.h"
-#include "tal/vector2.h"
-#include "tal/vector3.h"
-#include "tal/vector3i.h"
-#include "tal/wrapped.h"
-#include "types.h"
+#include <memory>  // for allocator_traits<>:...
+
+#include "core/godot_utils.h"          // for clean_children
+#include "core/hex_mesh.h"             // for SimpleMesh, HexMesh...
+#include "core/hexagonal_utility.h"    // for HexagonalUtility
+#include "core/mesh.h"                 // for SotaMesh
+#include "core/rectangular_utility.h"  // for RectangularUtility
+#include "core/tile_mesh.h"            // for TileMesh
+#include "core/utils.h"                // for pointy_top_x_offset
+#include "misc/cube_coordinates.h"     // for OffsetCoordinates
+#include "misc/tile.h"                 // for Tile
+#include "misc/types.h"                // for ClipOptions
+#include "primitives/hexagon.h"        // for make_hexagon_at_pos...
+#include "tal/arrays.h"                // for Array
+#include "tal/godot_core.h"            // for D_METHOD, ClassDB
+#include "tal/material.h"              // for ShaderMaterial
+#include "tal/reference.h"             // for Ref
+#include "tal/shader.h"                // for Shader
+#include "tal/vector3.h"               // for Vector3
+#include "tal/vector3i.h"              // for Vector3i
 
 namespace sota {
 

--- a/src/core/hex_grid.h
+++ b/src/core/hex_grid.h
@@ -1,20 +1,23 @@
 #pragma once
 
-#include <map>
+#include <map>  // for map
 #include <memory>
+#include <vector>  // for vector
 
 #include "core/hex_mesh.h"
-#include "misc/cube_coordinates.h"
+#include "misc/cube_coordinates.h"  // for CubeCoordinates
 #include "misc/tile.h"
 #include "misc/types.h"
-#include "tal/arrays.h"
-#include "tal/node.h"
-#include "tal/reference.h"
-#include "tal/shader.h"
-#include "tal/vector3i.h"
+#include "tal/arrays.h"     // for Array
+#include "tal/node.h"       // for Node3D
+#include "tal/reference.h"  // for Ref
+#include "tal/shader.h"     // for Shader
+#include "tal/vector3i.h"   // for Vector3i
 #include "tal/wrapped.h"
 
 namespace sota {
+class Tile;
+class TileMesh;
 
 using TilesLayout = std::vector<std::vector<Tile*>>;
 

--- a/src/core/hex_mesh.cpp
+++ b/src/core/hex_mesh.cpp
@@ -1,18 +1,20 @@
 #include "hex_mesh.h"
 
-#include <memory>
-#include <type_traits>
+#include <cmath>   // for sqrt
+#include <memory>  // for make_unique
+#include <vector>  // for vector
 
-#include "core/utils.h"
-#include "mesh.h"
-#include "primitives/edge.h"
-#include "primitives/face.h"
-#include "primitives/hexagon.h"
-#include "primitives/triangle.h"
-#include "tal/arrays.h"
-#include "tal/godot_core.h"
-#include "tal/vector2.h"
-#include "tal/vector3.h"
+#include "core/mesh.h"           // for SotaMesh, Tess...
+#include "core/utils.h"          // for radius, small_...
+#include "misc/types.h"          // for ClipOptions
+#include "primitives/edge.h"     // for Edge
+#include "primitives/hexagon.h"  // for Hexagon, make_...
+#include "primitives/polygon.h"  // for RegularPolygon
+#include "tal/arrays.h"          // for Vector3Array
+#include "tal/godot_core.h"      // for D_METHOD, ClassDB
+#include "tal/reference.h"       // for Ref
+#include "tal/vector2.h"         // for Vector2
+#include "tal/vector3.h"         // for Vector3
 
 namespace sota {
 

--- a/src/core/hex_mesh.h
+++ b/src/core/hex_mesh.h
@@ -2,21 +2,22 @@
 
 #include <memory>
 
-#include "core/mesh.h"
-#include "core/tile_mesh.h"
-#include "misc/types.h"
+#include "core/mesh.h"       // for SotaMesh, Orientation, Tess...
+#include "core/tile_mesh.h"  // for TileMesh
+#include "misc/types.h"      // for ClipOptions
 #include "primitives/edge.h"
 #include "primitives/face.h"
 #include "primitives/hexagon.h"
 #include "primitives/polygon.h"
 #include "primitives/triangle.h"
 #include "tal/arrays.h"
-#include "tal/material.h"
-#include "tal/reference.h"
+#include "tal/material.h"   // for Material
+#include "tal/reference.h"  // for Ref
 #include "tal/vector3.h"
 #include "tal/wrapped.h"
 
 namespace sota {
+class Hexagon;
 
 struct HexMeshParams {
   int id{0};

--- a/src/core/hexagonal_utility.cpp
+++ b/src/core/hexagonal_utility.cpp
@@ -1,8 +1,10 @@
 #include "core/hexagonal_utility.h"
 
-#include "core/utils.h"
-#include "misc/cube_coordinates.h"
-#include "misc/types.h"
+#include <memory>  // for allocator_traits<>::value_type
+
+#include "core/utils.h"             // for is_odd
+#include "misc/cube_coordinates.h"  // for OffsetCoordinates, cubeToOffset
+#include "tal/vector3i.h"           // for Vector3i
 
 namespace sota {
 

--- a/src/core/mesh.cpp
+++ b/src/core/mesh.cpp
@@ -1,9 +1,9 @@
 #include "core/mesh.h"
 
-#include "core/dummy_mesher.h"
-#include "tal/arrays.h"
-#include "tal/godot_core.h"
-#include "tal/vector3.h"
+#include "core/dummy_mesher.h"  // for DummyMesher
+#include "tal/arrays.h"         // for Vector3Array, Array, ByteArray
+#include "tal/godot_core.h"     // for D_METHOD, ClassDB, Property...
+#include "tal/vector3.h"        // for Vector3
 
 namespace sota {
 

--- a/src/core/mesh.h
+++ b/src/core/mesh.h
@@ -1,15 +1,17 @@
 #pragma once
 
-#include <memory>
-#include <vector>
+#include <memory>   // for unique_ptr
+#include <utility>  // for move, swap
+#include <vector>   // for vector
 
-#include "primitives/edge.h"
-#include "primitives/face.h"
-#include "primitives/polygon.h"
-#include "primitives/triangle.h"
-#include "tal/arrays.h"
-#include "tal/mesh.h"
-#include "tal/vector3.h"
+#include "mesh.h"
+#include "primitives/edge.h"      // for Edge
+#include "primitives/face.h"      // for Face
+#include "primitives/polygon.h"   // for RegularPolygon
+#include "primitives/triangle.h"  // for Triangle
+#include "tal/arrays.h"           // for Vector3Array
+#include "tal/mesh.h"             // for PrimitiveMesh
+#include "tal/vector3.h"          // for Vector3
 
 namespace sota {
 

--- a/src/core/pent_mesh.cpp
+++ b/src/core/pent_mesh.cpp
@@ -1,17 +1,16 @@
 #include "core/pent_mesh.h"
 
-#include <cmath>
-#include <memory>
+#include <cmath>   // for sin, tan
+#include <memory>  // for make_unique
+#include <vector>  // for vector
 
-#include "algo/constants.h"
-#include "mesh.h"
-#include "primitives/edge.h"
-#include "primitives/face.h"
-#include "primitives/pentagon.h"
-#include "primitives/triangle.h"
-#include "tal/reference.h"
-#include "tal/vector2.h"
-#include "tal/vector3.h"
+#include "algo/constants.h"       // for PI
+#include "core/mesh.h"            // for SotaMesh
+#include "primitives/pentagon.h"  // for Pentagon, make...
+#include "primitives/polygon.h"   // for RegularPolygon
+#include "tal/arrays.h"           // for Vector3Array
+#include "tal/vector2.h"          // for Vector2
+#include "tal/vector3.h"          // for Vector3
 
 namespace sota {
 

--- a/src/core/pent_mesh.h
+++ b/src/core/pent_mesh.h
@@ -2,13 +2,15 @@
 
 #include <memory>
 
-#include "core/mesh.h"
+#include "core/mesh.h"  // for SotaMesh, Orientation, Tess...
 #include "primitives/edge.h"
 #include "primitives/pentagon.h"
 #include "primitives/polygon.h"
-#include "tal/material.h"
-#include "tal/reference.h"
+#include "tal/material.h"   // for Material
+#include "tal/reference.h"  // for Ref
+
 namespace sota {
+class Pentagon;
 
 struct PentagonMeshParams {
   int id{0};

--- a/src/core/rectangular_utility.cpp
+++ b/src/core/rectangular_utility.cpp
@@ -1,6 +1,6 @@
 #include "core/rectangular_utility.h"
 
-#include "misc/types.h"
+#include "tal/vector3i.h"  // for Vector3i
 
 namespace sota {
 

--- a/src/core/utils.cpp
+++ b/src/core/utils.cpp
@@ -1,10 +1,14 @@
 #include "core/utils.h"
 
-#include <cmath>
+#include <cmath>  // for abs
 
-#include "algo/constants.h"
-#include "tal/arrays.h"
-#include "tal/vector3i.h"
+#include <cmath>  // for sqrt, cos, sin
+
+#include "algo/constants.h"  // for PI
+#include "tal/arrays.h"      // for Array, Vector3Array
+#include "tal/vector2.h"     // for Vector2
+#include "tal/vector3.h"     // for Vector3
+#include "tal/vector3i.h"    // for Vector3i
 
 namespace sota {
 

--- a/src/core/utils.h
+++ b/src/core/utils.h
@@ -1,7 +1,8 @@
 #pragma once
-#include "tal/arrays.h"
-#include "tal/vector2.h"
-#include "tal/vector3.h"
+
+#include "tal/arrays.h"   // for Array, Vector3Array
+#include "tal/vector2.h"  // for Vector2
+#include "tal/vector3.h"  // for Vector3
 
 namespace sota {
 

--- a/src/honeycomb/honeycomb.cpp
+++ b/src/honeycomb/honeycomb.cpp
@@ -1,27 +1,40 @@
 #include "honeycomb.h"
 
-#include <algorithm>
-#include <memory>
-#include <random>
-#include <unordered_map>
+#include <algorithm>      // for sort, max, min
+#include <cmath>          // for pow
+#include <limits>         // for numeric_limits
+#include <memory>         // for allocator_traits<>:...
+#include <random>         // for mt19937, uniform_in...
+#include <unordered_map>  // for unordered_map, unor...
+#include <utility>        // for pair
+#include <vector>         // for vector
 
-#include "core/utils.h"
-#include "cube_coordinates.h"
-#include "general_utility.h"
-#include "godot_utils.h"
-#include "hexagonal_utility.h"
-#include "honeycomb/honeycomb_cell.h"
-#include "honeycomb/honeycomb_honey.h"
-#include "primitives/hexagon.h"
-#include "rectangular_utility.h"
-#include "tal/arrays.h"
-#include "tal/callable.h"
-#include "tal/godot_core.h"
-#include "tal/object.h"
-#include "tal/vector2.h"
-#include "tal/vector3.h"
-#include "tile.h"
-#include "types.h"
+#include "core/general_utility.h"       // for GeneralUtility
+#include "core/godot_utils.h"           // for clean_children
+#include "core/hex_grid.h"              // for TilesLayout
+#include "core/hex_mesh.h"              // for HexMesh, HexMeshParams
+#include "core/hexagonal_utility.h"     // for HexagonalUtility
+#include "core/mesh.h"                  // for SotaMesh
+#include "core/rectangular_utility.h"   // for RectangularUtility
+#include "core/tile_mesh.h"             // for TileMesh
+#include "core/utils.h"                 // for pointy_top_x_offset
+#include "honeycomb/honeycomb_cell.h"   // for HoneycombCell, Hone...
+#include "honeycomb/honeycomb_honey.h"  // for HoneycombHoney, Hon...
+#include "misc/cube_coordinates.h"      // for OffsetCoordinates
+#include "misc/tile.h"                  // for HoneycombTile, Tile
+#include "misc/types.h"                 // for GroupedMeshVertices
+#include "primitives/hexagon.h"         // for make_hexagon_at_pos...
+#include "tal/arrays.h"                 // for Array
+#include "tal/callable.h"               // for Callable
+#include "tal/godot_core.h"             // for D_METHOD, ClassDB
+#include "tal/material.h"               // for ShaderMaterial
+#include "tal/noise.h"                  // for FastNoiseLite
+#include "tal/reference.h"              // for Ref
+#include "tal/shader.h"                 // for Shader
+#include "tal/texture.h"                // for Texture
+#include "tal/vector2.h"                // for Vector2
+#include "tal/vector3.h"                // for Vector3
+#include "tal/vector3i.h"               // for Vector3i
 
 namespace sota {
 

--- a/src/honeycomb/honeycomb.h
+++ b/src/honeycomb/honeycomb.h
@@ -1,14 +1,18 @@
 #pragma once
 
-#include "core/hex_grid.h"
+#include <functional>  // for function
+
+#include "core/hex_grid.h"  // for HexGrid
 #include "honeycomb/honeycomb_honey.h"
-#include "tal/arrays.h"
-#include "tal/noise.h"
-#include "tal/reference.h"
-#include "tal/shader.h"
-#include "tal/texture.h"
-#include "tal/vector3.h"
+#include "tal/arrays.h"     // for Array
+#include "tal/noise.h"      // for FastNoiseLite
+#include "tal/reference.h"  // for Ref
+#include "tal/shader.h"     // for Shader
+#include "tal/texture.h"    // for Texture
+#include "tal/vector3.h"    // for Vector3
+
 namespace sota {
+class HoneycombHoney;
 
 class Honeycomb : public HexGrid {
   GDCLASS(Honeycomb, HexGrid)

--- a/src/honeycomb/honeycomb_cell.cpp
+++ b/src/honeycomb/honeycomb_cell.cpp
@@ -1,14 +1,26 @@
 #include "honeycomb/honeycomb_cell.h"
 
-#include "core/general_utility.h"
-#include "core/utils.h"
-#include "hex_mesh.h"
-#include "misc/utilities.h"
-#include "tal/callable.h"
-#include "tal/camera.h"
-#include "tal/event.h"
-#include "tal/godot_core.h"
-#include "tal/vector2.h"
+#include <cmath>  // for abs
+
+#include <algorithm>  // for min
+#include <limits>     // for numeric_limits
+#include <utility>    // for tuple_element<...
+#include <vector>     // for vector
+
+#include "core/general_utility.h"  // for GeneralUtility
+#include "core/hex_mesh.h"         // for HexMesh
+#include "core/utils.h"            // for cosrp
+#include "misc/types.h"            // for GroupedMeshVer...
+#include "misc/utilities.h"        // for to_point_divis...
+#include "primitives/hexagon.h"    // for Hexagon
+#include "primitives/polygon.h"    // for RegularPolygon
+#include "tal/callable.h"          // for Callable
+#include "tal/camera.h"            // for Camera3D
+#include "tal/event.h"             // for InputEventMouse
+#include "tal/godot_core.h"        // for D_METHOD, ClassDB
+#include "tal/material.h"          // for ShaderMaterial
+#include "tal/noise.h"             // for FastNoiseLite
+#include "tal/vector2.h"           // for Vector2
 
 namespace sota {
 

--- a/src/honeycomb/honeycomb_cell.h
+++ b/src/honeycomb/honeycomb_cell.h
@@ -1,12 +1,19 @@
 #pragma once
 
-#include "core/hex_mesh.h"
-#include "misc/types.h"
-#include "tal/camera.h"
-#include "tal/event.h"
-#include "tal/material.h"
-#include "tal/noise.h"
+#include <stdint.h>  // for int32_t
+
+#include "core/hex_mesh.h"   // for HexMesh, HexMeshParams
+#include "core/tile_mesh.h"  // for TileMesh
+#include "misc/types.h"      // for GroupedMeshVertices
+#include "tal/camera.h"      // for Camera3D
+#include "tal/event.h"       // for InputEvent
+#include "tal/material.h"    // for ShaderMaterial
+#include "tal/noise.h"       // for FastNoiseLite
+#include "tal/reference.h"   // for Ref
+#include "tal/vector3.h"     // for Vector3
+
 namespace sota {
+class Hexagon;
 
 struct HoneycombCellMeshParams {
   HexMeshParams hex_mesh_params;

--- a/src/honeycomb/honeycomb_honey.cpp
+++ b/src/honeycomb/honeycomb_honey.cpp
@@ -1,15 +1,21 @@
 #include "honeycomb/honeycomb_honey.h"
 
-#include <memory>
+#include <algorithm>  // for max, min
+#include <memory>     // for make_unique
+#include <vector>     // for vector
 
-#include "core/general_utility.h"
-#include "hex_mesh.h"
-#include "misc/types.h"
-#include "misc/utilities.h"
-#include "primitives/hexagon.h"
-#include "tal/callable.h"
-#include "tal/godot_core.h"
-#include "tal/vector3.h"
+#include "core/general_utility.h"  // for VolumeMeshProc...
+#include "core/hex_mesh.h"         // for HexMesh, HexMe...
+#include "core/mesh.h"             // for Orientation
+#include "misc/types.h"            // for GroupedMeshVer...
+#include "misc/utilities.h"        // for to_point_divis...
+#include "primitives/hexagon.h"    // for Hexagon, make_...
+#include "primitives/polygon.h"    // for RegularPolygon
+#include "tal/callable.h"          // for Callable
+#include "tal/godot_core.h"        // for D_METHOD, ClassDB
+#include "tal/noise.h"             // for FastNoiseLite
+#include "tal/reference.h"         // for Ref
+#include "tal/vector3.h"           // for Vector3
 
 namespace sota {
 

--- a/src/honeycomb/honeycomb_honey.h
+++ b/src/honeycomb/honeycomb_honey.h
@@ -1,14 +1,18 @@
 #pragma once
 
-#include <memory>
+#include <limits>   // for numeric_limits
+#include <memory>   // for unique_ptr
+#include <utility>  // for pair
 
-#include "core/general_utility.h"
-#include "core/hex_mesh.h"
-#include "misc/types.h"
-#include "tal/noise.h"
-#include "tal/reference.h"
+#include "core/general_utility.h"  // for MeshProcessor
+#include "core/hex_mesh.h"         // for HexMesh, HexMeshParams
+#include "core/tile_mesh.h"        // for TileMesh
+#include "misc/types.h"            // for GroupedMeshVertices
+#include "tal/noise.h"             // for FastNoiseLite
+#include "tal/reference.h"         // for Ref
 
 namespace sota {
+class Hexagon;
 
 struct HoneycombHoneyMeshParams {
   HexMeshParams hex_mesh_params;

--- a/src/polyhedron/hex_polyhedron.cpp
+++ b/src/polyhedron/hex_polyhedron.cpp
@@ -1,28 +1,28 @@
 #include "polyhedron/hex_polyhedron.h"
 
-#include <algorithm>
-#include <vector>
+#include <algorithm>  // for transform, max, min
+#include <cmath>      // for sqrt, round, cos, sin
+#include <iterator>   // for back_insert_iterator
+#include <limits>     // for numeric_limits
+#include <vector>     // for vector
 
-#include "algo/constants.h"
-#include "biome_calculator.h"
-#include "core/godot_utils.h"
-#include "core/utils.h"
-#include "mesh.h"
-#include "pent_mesh.h"
-#include "primitives/hexagon.h"
-#include "primitives/pentagon.h"
-#include "prism_pent_mesh.h"
-#include "tal/arrays.h"
-#include "tal/callable.h"
-#include "tal/godot_core.h"
-#include "tal/material.h"
-#include "tal/mesh.h"
-#include "tal/noise.h"
-#include "tal/shader.h"
-#include "tal/vector2.h"
-#include "tal/vector3.h"
-#include "tal/vector3i.h"
-#include "types.h"
+#include "algo/constants.h"         // for PI
+#include "core/godot_utils.h"       // for clean_children
+#include "core/utils.h"             // for map2d_to_3d, ico_in...
+#include "misc/biome_calculator.h"  // for BiomeCalculator
+#include "misc/types.h"             // for Biome, Biome::HILL
+#include "primitives/hexagon.h"     // for Hexagon
+#include "primitives/pentagon.h"    // for Pentagon
+#include "tal/arrays.h"             // for Vector3Array, Array
+#include "tal/callable.h"           // for Callable
+#include "tal/godot_core.h"         // for D_METHOD, ClassDB
+#include "tal/material.h"           // for ShaderMaterial
+#include "tal/noise.h"              // for FastNoiseLite
+#include "tal/shader.h"             // for Shader
+#include "tal/texture.h"            // for Texture
+#include "tal/vector2.h"            // for Vector2
+#include "tal/vector3.h"            // for Vector3
+#include "tal/vector3i.h"           // for Vector3i
 
 namespace sota {
 

--- a/src/polyhedron/hex_polyhedron.h
+++ b/src/polyhedron/hex_polyhedron.h
@@ -1,25 +1,33 @@
 #pragma once
 
+#include <map>  // for map
 #include <memory>
+#include <unordered_map>  // for unordered_map
+#include <utility>        // for pair
+#include <vector>         // for vector
 
-#include "misc/types.h"
+#include "core/tile_mesh.h"  // for TileMesh
+#include "misc/types.h"      // for Biome
 #include "polyhedron/polyhedron_mesh_processor.h"
 #include "polyhedron/polyhedron_noise_processor.h"
 #include "polyhedron/polyhedron_prism_processor.h"
 #include "polyhedron/polyhedron_ridge_processor.h"
 #include "primitives/hexagon.h"
 #include "primitives/pentagon.h"
-#include "tal/arrays.h"
-#include "tal/material.h"
+#include "tal/arrays.h"    // for Vector3Array
+#include "tal/material.h"  // for ShaderMaterial
 #include "tal/mesh.h"
-#include "tal/node.h"
-#include "tal/noise.h"
-#include "tal/shader.h"
-#include "tal/texture.h"
-#include "tal/vector3.h"
-#include "tal/vector3i.h"
+#include "tal/node.h"       // for Node3D
+#include "tal/noise.h"      // for FastNoiseLite
+#include "tal/reference.h"  // for Ref
+#include "tal/shader.h"     // for Shader
+#include "tal/texture.h"    // for Texture
+#include "tal/vector3.h"    // for Vector3
+#include "tal/vector3i.h"   // for Vector3i
 
 namespace sota {
+class Hexagon;
+class Pentagon;
 
 class Polyhedron : public Node3D {
   GDCLASS(Polyhedron, Node3D)

--- a/src/polyhedron/polyhedron_noise_processor.cpp
+++ b/src/polyhedron/polyhedron_noise_processor.cpp
@@ -1,16 +1,19 @@
 #include "polyhedron/polyhedron_noise_processor.h"
 
-#include "core/hex_mesh.h"
-#include "misc/types.h"
-#include "misc/utilities.h"
-#include "pent_mesh.h"
-#include "polyhedron/hex_polyhedron.h"
-#include "polyhedron/noise_polyhedron.h"
-#include "primitives/pentagon.h"
-#include "prism_pent_mesh.h"
-#include "ridge_impl/plain_mesh.h"
-#include "ridge_impl/ridge_mesh.h"
-#include "tal/godot_core.h"
+#include <algorithm>  // for max, min
+#include <limits>     // for numeric_limits
+
+#include "core/hex_mesh.h"                // for HexMeshParams
+#include "core/mesh.h"                    // for Orientation, Orient...
+#include "core/pent_mesh.h"               // for PentagonMeshParams
+#include "core/tile_mesh.h"               // for TileMesh
+#include "misc/types.h"                   // for ClipOptions, Biome
+#include "polyhedron/hex_polyhedron.h"    // for Polyhedron
+#include "polyhedron/noise_polyhedron.h"  // for NoisePolyhedron
+#include "primitives/hexagon.h"           // for Hexagon
+#include "primitives/pentagon.h"          // for Pentagon
+#include "ridge_impl/plain_mesh.h"        // for PlainMesh
+#include "ridge_impl/ridge_mesh.h"        // for make_ridge_hex_mesh
 
 namespace sota {
 

--- a/src/polyhedron/polyhedron_noise_processor.h
+++ b/src/polyhedron/polyhedron_noise_processor.h
@@ -1,9 +1,20 @@
 #pragma once
 
-#include "polyhedron/polyhedron_mesh_processor.h"
-#include "tile_mesh.h"
+#include <map>      // for map
+#include <utility>  // for pair
+#include <vector>   // for vector
+
+#include "core/tile_mesh.h"
+#include "misc/types.h"                            // for Biome
+#include "polyhedron/polyhedron_mesh_processor.h"  // for PolyhedronProcessor
+#include "tal/material.h"                          // for ShaderMaterial
+#include "tal/reference.h"                         // for Ref
 
 namespace sota {
+class Hexagon;
+class Pentagon;
+class Polyhedron;
+class TileMesh;
 
 class PolyhedronNoiseProcessor : public PolyhedronProcessor {
  public:

--- a/src/polyhedron/polyhedron_prism_processor.cpp
+++ b/src/polyhedron/polyhedron_prism_processor.cpp
@@ -1,16 +1,22 @@
 #include "polyhedron/polyhedron_prism_processor.h"
 
-#include "core/hex_mesh.h"
-#include "polyhedron/hex_polyhedron.h"
-#include "primitives/pentagon.h"
-#include "prism_hex_mesh.h"
-#include "prism_pent_mesh.h"
-#include "prism_polyhedron.h"
-#include "tal/godot_core.h"
-#include "tal/mesh.h"
-#include "tal/reference.h"
-#include "types.h"
-#include "utils.h"
+#include <unordered_map>  // for unordered_map
+#include <vector>         // for vector
+
+#include "core/hex_mesh.h"               // for HexMeshParams, HexMesh
+#include "core/mesh.h"                   // for Orientation, Orient...
+#include "core/pent_mesh.h"              // for PentagonMeshParams
+#include "core/tile_mesh.h"              // for TileMesh
+#include "misc/types.h"                  // for Biome, ClipOptions
+#include "polyhedron/hex_polyhedron.h"   // for Polyhedron
+#include "primitives/hexagon.h"          // for Hexagon
+#include "primitives/pentagon.h"         // for Pentagon
+#include "prism_impl/prism_hex_mesh.h"   // for PrismHexTile, Prism...
+#include "prism_impl/prism_pent_mesh.h"  // for PrismPentTile, Pris...
+#include "prism_polyhedron.h"            // for PrismPolyhedron
+#include "tal/material.h"                // for ShaderMaterial
+#include "tal/mesh.h"                    // for MeshInstance3D
+#include "tal/reference.h"               // for Ref
 
 namespace sota {
 

--- a/src/polyhedron/polyhedron_prism_processor.h
+++ b/src/polyhedron/polyhedron_prism_processor.h
@@ -1,10 +1,14 @@
 #pragma once
 
-#include "polyhedron/polyhedron_mesh_processor.h"
-#include "tal/material.h"
-#include "tal/reference.h"
+#include "misc/types.h"                            // for Biome
+#include "polyhedron/polyhedron_mesh_processor.h"  // for PolyhedronProcessor
+#include "tal/material.h"                          // for ShaderMaterial
+#include "tal/reference.h"                         // for Ref
 
 namespace sota {
+class Hexagon;
+class Pentagon;
+class Polyhedron;
 
 class PolyhedronPrismProcessor : public PolyhedronProcessor {
  public:

--- a/src/polyhedron/polyhedron_ridge_processor.cpp
+++ b/src/polyhedron/polyhedron_ridge_processor.cpp
@@ -1,25 +1,32 @@
 #include "polyhedron/polyhedron_ridge_processor.h"
 
-#include <algorithm>
-#include <iterator>
-#include <memory>
-#include <numeric>
-#include <unordered_set>
-#include <vector>
+#include <algorithm>      // for copy_if, find, max
+#include <functional>     // for reference_wrapper
+#include <iterator>       // for back_insert_iterator
+#include <limits>         // for numeric_limits
+#include <memory>         // for make_unique, alloca...
+#include <numeric>        // for accumulate
+#include <optional>       // for optional
+#include <unordered_set>  // for unordered_set
+#include <vector>         // for vector, vector<>::i...
 
-#include "core/hex_mesh.h"
-#include "misc/utilities.h"
-#include "polyhedron/hex_polyhedron.h"
-#include "polyhedron/ridge_polyhedron.h"
-#include "primitives/pentagon.h"
-#include "ridge_group.h"
-#include "ridge_impl/plain_mesh.h"
-#include "ridge_mesh.h"
-#include "ridge_set.h"
-#include "tal/godot_core.h"
-#include "tile_mesh.h"
-#include "types.h"
-#include "utils.h"
+#include "core/hex_mesh.h"                // for HexMeshParams
+#include "core/mesh.h"                    // for Orientation, Orient...
+#include "core/pent_mesh.h"               // for PentagonMeshParams
+#include "core/tile_mesh.h"               // for TileMesh
+#include "misc/types.h"                   // for Biome, ClipOptions
+#include "misc/utilities.h"               // for get_biome, create_h...
+#include "polyhedron/hex_polyhedron.h"    // for Polyhedron
+#include "polyhedron/ridge_polyhedron.h"  // for RidgePolyhedron
+#include "primitives/hexagon.h"           // for Hexagon
+#include "primitives/pentagon.h"          // for Pentagon
+#include "ridge_impl/ridge_config.h"      // for RidgeConfig
+#include "ridge_impl/ridge_group.h"       // for RidgeGroup, GroupOf...
+#include "ridge_impl/ridge_mesh.h"        // for RidgeMesh, RidgeHex...
+#include "ridge_impl/ridge_set.h"         // for RidgeSet
+#include "tal/godot_core.h"               // for print, printerr
+#include "tal/reference.h"                // for Ref
+#include "tal/vector3.h"                  // for Vector3
 
 namespace sota {
 

--- a/src/polyhedron/polyhedron_ridge_processor.h
+++ b/src/polyhedron/polyhedron_ridge_processor.h
@@ -1,19 +1,26 @@
 #pragma once
 
+#include <map>  // for map
 #include <memory>
-#include <vector>
+#include <utility>  // for pair
+#include <vector>   // for vector
 
-#include "polyhedron/polyhedron_mesh_processor.h"
-#include "ridge.h"
-#include "ridge_impl/ridge_based_object.h"
+#include "core/tile_mesh.h"                        // for TileMesh
+#include "misc/types.h"                            // for Biome
+#include "polyhedron/polyhedron_mesh_processor.h"  // for PolyhedronProcessor
+#include "ridge_impl/ridge.h"
+#include "ridge_impl/ridge_based_object.h"  // for RidgeBased
 #include "ridge_impl/ridge_group.h"
 #include "ridge_impl/ridge_mesh.h"
 #include "ridge_impl/ridge_set.h"
-#include "tal/reference.h"
-#include "tile_mesh.h"
+#include "tal/material.h"   // for ShaderMaterial
+#include "tal/reference.h"  // for Ref
 
 namespace sota {
 
+class Hexagon;
+class Pentagon;
+class Polyhedron;
 class RidgePolyhedron;
 
 class PolyhedronRidgeProcessor : public PolyhedronProcessor, public RidgeBased {

--- a/src/polyhedron/prism_polyhedron.cpp
+++ b/src/polyhedron/prism_polyhedron.cpp
@@ -1,6 +1,8 @@
 #include "polyhedron/prism_polyhedron.h"
 
-#include "tal/godot_core.h"
+#include <utility>  // for pair
+
+#include "tal/godot_core.h"  // for D_METHOD, ClassDB
 
 namespace sota {
 

--- a/src/polyhedron/prism_polyhedron.h
+++ b/src/polyhedron/prism_polyhedron.h
@@ -1,6 +1,15 @@
 #pragma once
 
-#include "polyhedron/hex_polyhedron.h"
+#include <unordered_map>  // for unordered_map
+#include <vector>         // for vector
+
+#include "misc/types.h"                  // for Biome, Biome::HILL, Biome::...
+#include "polyhedron/hex_polyhedron.h"   // for Polyhedron
+#include "polyhedron_prism_processor.h"  // for PolyhedronPrismProcessor
+#include "primitives/hexagon.h"          // for Hexagon
+#include "primitives/pentagon.h"         // for Pentagon
+#include "tal/material.h"                // for ShaderMaterial
+#include "tal/reference.h"               // for Ref
 
 namespace sota {
 

--- a/src/polyhedron/ridge_based_polyhedron.cpp
+++ b/src/polyhedron/ridge_based_polyhedron.cpp
@@ -1,9 +1,9 @@
 #include "polyhedron/ridge_based_polyhedron.h"
 
-#include "hex_polyhedron.h"
-#include "misc/biome_calculator.h"
-#include "tal/callable.h"
-#include "tal/godot_core.h"
+#include "tal/callable.h"    // for Callable
+#include "tal/godot_core.h"  // for D_METHOD, ClassDB
+#include "tal/material.h"    // for ShaderMaterial
+#include "tal/reference.h"   // for Ref
 
 namespace sota {
 

--- a/src/polyhedron/ridge_based_polyhedron.h
+++ b/src/polyhedron/ridge_based_polyhedron.h
@@ -1,8 +1,11 @@
 #pragma once
 
-#include "polyhedron/hex_polyhedron.h"
-#include "tal/material.h"
-#include "tal/reference.h"
+#include <vector>  // for vector
+
+#include "polyhedron/hex_polyhedron.h"  // for Polyhedron
+#include "tal/material.h"               // for ShaderMaterial
+#include "tal/noise.h"                  // for FastNoiseLite
+#include "tal/reference.h"              // for Ref
 
 namespace sota {
 

--- a/src/primitives/hexagon.cpp
+++ b/src/primitives/hexagon.cpp
@@ -1,8 +1,11 @@
 #include "primitives/hexagon.h"
 
-#include "algo/constants.h"
-#include "core/utils.h"
-#include "tal/godot_core.h"
+#include <cmath>  // for cos, sin
+
+#include "algo/constants.h"  // for PI
+#include "core/utils.h"      // for radius
+#include "tal/godot_core.h"  // for printerr
+#include "tal/vector3.h"     // for Vector3
 
 namespace sota {
 

--- a/src/primitives/hexagon.h
+++ b/src/primitives/hexagon.h
@@ -1,7 +1,9 @@
 #pragma once
 
-#include "primitives/polygon.h"
-#include "tal/vector3.h"
+#include <vector>                // for vector
+
+#include "primitives/polygon.h"  // for RegularPolygon
+#include "tal/vector3.h"         // for Vector3
 
 namespace sota {
 

--- a/src/primitives/pentagon.cpp
+++ b/src/primitives/pentagon.cpp
@@ -1,8 +1,11 @@
 #include "primitives/pentagon.h"
 
-#include "algo/constants.h"
-#include "core/utils.h"
-#include "tal/godot_core.h"
+#include <cmath>  // for cos, sin
+
+#include "algo/constants.h"  // for PI
+#include "core/utils.h"      // for radius
+#include "tal/godot_core.h"  // for printerr
+#include "tal/vector3.h"     // for Vector3
 
 namespace sota {
 

--- a/src/primitives/pentagon.h
+++ b/src/primitives/pentagon.h
@@ -1,7 +1,9 @@
 #pragma once
 
-#include "primitives/polygon.h"
-#include "tal/vector3.h"
+#include <vector>  // for vector
+
+#include "primitives/polygon.h"  // for RegularPolygon
+#include "tal/vector3.h"         // for Vector3
 
 namespace sota {
 

--- a/src/primitives/polygon.cpp
+++ b/src/primitives/polygon.cpp
@@ -1,5 +1,9 @@
 #include "primitives/polygon.h"
 
+#include <algorithm>  // for sort
+
+#include "tal/vector3.h"  // for Vector3
+
 namespace sota {
 
 void RegularPolygon::sort_points() {

--- a/src/primitives/polygon.h
+++ b/src/primitives/polygon.h
@@ -2,9 +2,9 @@
 
 #include <algorithm>
 #include <cmath>
-#include <vector>
+#include <vector>         // for vector
 
-#include "tal/vector3.h"
+#include "tal/vector3.h"  // for Vector3
 
 namespace sota {
 

--- a/src/prism_impl/prism_hex_mesh.cpp
+++ b/src/prism_impl/prism_hex_mesh.cpp
@@ -1,9 +1,8 @@
 #include "prism_impl/prism_hex_mesh.h"
 
-#include "hex_mesh.h"
-#include "misc/types.h"
-#include "primitives/triangle.h"
-#include "tal/godot_core.h"
+#include "core/hex_mesh.h"       // for HexMesh
+#include "primitives/hexagon.h"  // for Hexagon
+#include "tal/godot_core.h"      // for D_METHOD, ClassDB, PropertyInfo
 
 namespace sota {
 PrismHexMesh::PrismHexMesh(Hexagon hex, PrismHexMeshParams params) : HexMesh(hex, params.hex_mesh_params) {

--- a/src/prism_impl/prism_hex_mesh.h
+++ b/src/prism_impl/prism_hex_mesh.h
@@ -1,10 +1,12 @@
 #pragma once
 
-#include "core/hex_mesh.h"
-#include "primitives/hexagon.h"
+#include "core/hex_mesh.h"   // for HexMesh, HexMeshParams
+#include "core/tile_mesh.h"  // for TileMesh
+#include "misc/types.h"
+#include "primitives/hexagon.h"  // for Hexagon
 #include "tal/godot_core.h"
+#include "tal/reference.h"  // for Ref
 #include "tal/wrapped.h"
-#include "types.h"
 
 namespace sota {
 

--- a/src/prism_impl/prism_pent_mesh.cpp
+++ b/src/prism_impl/prism_pent_mesh.cpp
@@ -1,9 +1,7 @@
 #include "prism_impl/prism_pent_mesh.h"
 
-#include "misc/types.h"
-#include "pent_mesh.h"
-#include "primitives/triangle.h"
-#include "tal/godot_core.h"
+#include "core/pent_mesh.h"  // for PentMesh
+#include "tal/godot_core.h"  // for D_METHOD, ClassDB, PropertyInfo
 
 namespace sota {
 PrismPentMesh::PrismPentMesh(Pentagon pent, PrismPentMeshParams params) : PentMesh(pent, params.pent_mesh_params) {

--- a/src/prism_impl/prism_pent_mesh.h
+++ b/src/prism_impl/prism_pent_mesh.h
@@ -1,10 +1,12 @@
 #pragma once
 
-#include "core/pent_mesh.h"
-#include "core/tile_mesh.h"
+#include "core/pent_mesh.h"  // for PentMesh, PentagonMeshParams
+#include "core/tile_mesh.h"  // for TileMesh
 #include "core/utils.h"
+#include "misc/types.h"
+#include "primitives/pentagon.h"  // for Pentagon
+#include "tal/reference.h"        // for Ref
 #include "tal/wrapped.h"
-#include "types.h"
 
 namespace sota {
 

--- a/src/ridge_impl/hill_mesh.cpp
+++ b/src/ridge_impl/hill_mesh.cpp
@@ -1,10 +1,11 @@
 #include "hill_mesh.h"
 
-#include <cmath>
+#include <memory>  // for unique_ptr
 
-#include "mesh.h"
-#include "tal/vector2.h"
-#include "vector3.h"
+#include "core/mesh.h"           // for SotaMesh
+#include "general_utility.h"     // for MeshProcessor
+#include "primitives/polygon.h"  // for RegularPolygon
+#include "tal/vector3.h"         // for Vector3
 
 namespace sota {
 

--- a/src/ridge_impl/hill_mesh.h
+++ b/src/ridge_impl/hill_mesh.h
@@ -1,7 +1,11 @@
 #pragma once
 
-#include "primitives/pentagon.h"
-#include "ridge_impl/ridge_mesh.h"
+#include <map>      // for map
+#include <utility>  // for pair
+
+#include "primitives/hexagon.h"     // for Hexagon
+#include "primitives/pentagon.h"    // for Pentagon
+#include "ridge_impl/ridge_mesh.h"  // for RidgeMesh, RidgeHexMeshParams
 
 namespace sota {
 

--- a/src/ridge_impl/mountain_mesh.h
+++ b/src/ridge_impl/mountain_mesh.h
@@ -1,7 +1,11 @@
 #pragma once
 
-#include "primitives/pentagon.h"
-#include "ridge_impl/ridge_mesh.h"
+#include <map>      // for map
+#include <utility>  // for pair
+
+#include "primitives/hexagon.h"     // for Hexagon
+#include "primitives/pentagon.h"    // for Pentagon
+#include "ridge_impl/ridge_mesh.h"  // for RidgeMesh, RidgeHexMeshParams
 
 namespace sota {
 

--- a/src/ridge_impl/plain_mesh.cpp
+++ b/src/ridge_impl/plain_mesh.cpp
@@ -1,5 +1,9 @@
 #include "plain_mesh.h"
 
+#include "core/mesh.h"           // for SotaMesh
+#include "primitives/polygon.h"  // for RegularPolygon
+#include "tal/vector3.h"         // for Vector3
+
 namespace sota {
 
 void PlainMesh::calculate_final_heights(std::map<std::pair<int, int>, float>& distance_keeper, float diameter,

--- a/src/ridge_impl/plain_mesh.h
+++ b/src/ridge_impl/plain_mesh.h
@@ -1,7 +1,11 @@
 #pragma once
 
-#include "primitives/pentagon.h"
-#include "ridge_impl/ridge_mesh.h"
+#include <map>      // for map
+#include <utility>  // for pair
+
+#include "primitives/hexagon.h"     // for Hexagon
+#include "primitives/pentagon.h"    // for Pentagon
+#include "ridge_impl/ridge_mesh.h"  // for RidgeMesh, RidgeHexMeshParams
 
 namespace sota {
 

--- a/src/ridge_impl/ridge.h
+++ b/src/ridge_impl/ridge.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <vector>
+#include <vector>  // for vector
 
 #include "misc/types.h"
-#include "tal/vector3.h"
+#include "tal/vector3.h"  // for Vector3
 
 namespace sota {
 

--- a/src/ridge_impl/ridge_group.cpp
+++ b/src/ridge_impl/ridge_group.cpp
@@ -1,6 +1,13 @@
 #include "ridge_impl/ridge_group.h"
 
+#include <algorithm>  // for transform
+#include <iterator>   // for back_insert_iterator, back_inserter
+
+#include "ridge_impl/ridge_mesh.h"  // for RidgeMesh
+#include "ridge_impl/ridge_set.h"   // for RidgeSet
+
 namespace sota {
+class Ridge;
 
 void RidgeGroup::init_ridges(std::map<std::pair<int, int>, float>& distance_keeper, float offset, int divisions) {
   if (!_ridge_set) {

--- a/src/ridge_impl/ridge_group.h
+++ b/src/ridge_impl/ridge_group.h
@@ -1,12 +1,17 @@
 #pragma once
 
-#include <memory>
-#include <optional>
+#include <functional>  // for function
+#include <map>         // for map
+#include <memory>      // for unique_ptr
+#include <optional>    // for optional
+#include <utility>     // for move, pair
+#include <vector>      // for vector
 
 #include "ridge_impl/ridge_mesh.h"
-#include "ridge_impl/ridge_set.h"
+#include "ridge_impl/ridge_set.h"  // for RidgeSet
 
 namespace sota {
+class RidgeMesh;
 
 using GroupOfRidgeMeshes = std::vector<RidgeMesh*>;
 using BiomeGroups = std::vector<GroupOfRidgeMeshes>;

--- a/src/ridge_impl/ridge_hex_grid.cpp
+++ b/src/ridge_impl/ridge_hex_grid.cpp
@@ -1,31 +1,38 @@
 #include "ridge_hex_grid.h"
 
-#include <algorithm>
-#include <iostream>
-#include <limits>
-#include <memory>
-#include <unordered_map>
+#include <algorithm>      // for find, max, min
+#include <functional>     // for reference_wrapper
+#include <limits>         // for numeric_limits
+#include <memory>         // for make_unique, alloca...
+#include <unordered_map>  // for unordered_map, unor...
 
-#include "algo/dsu.h"
-#include "biome_calculator.h"
-#include "core/general_utility.h"
-#include "core/godot_utils.h"
-#include "core/hex_mesh.h"
-#include "core/hexagonal_utility.h"
-#include "core/rectangular_utility.h"
-#include "core/utils.h"
-#include "misc/cube_coordinates.h"
-#include "misc/tile.h"
-#include "misc/types.h"
-#include "misc/utilities.h"
-#include "primitives/hexagon.h"
-#include "ridge_group.h"
-#include "ridge_impl/ridge.h"
-#include "ridge_impl/ridge_config.h"
-#include "ridge_impl/ridge_mesh.h"
-#include "tal/callable.h"
-#include "tal/godot_core.h"
-#include "tal/vector3.h"
+#include "algo/dsu.h"                  // for DSU
+#include "core/general_utility.h"      // for GeneralUtility
+#include "core/godot_utils.h"          // for clean_children
+#include "core/hex_grid.h"             // for TilesLayout
+#include "core/hex_mesh.h"             // for HexMeshParams
+#include "core/hexagonal_utility.h"    // for HexagonalUtility
+#include "core/mesh.h"                 // for SotaMesh
+#include "core/rectangular_utility.h"  // for RectangularUtility
+#include "core/tile_mesh.h"            // for TileMesh
+#include "core/utils.h"                // for is_odd, pointy_top_...
+#include "misc/biome_calculator.h"     // for BiomeCalculator
+#include "misc/cube_coordinates.h"     // for CubeCoordinates
+#include "misc/tile.h"                 // for BiomeTile, Tile
+#include "misc/types.h"                // for Biome, GroupedMeshV...
+#include "misc/utilities.h"            // for create_hex_mesh
+#include "primitives/hexagon.h"        // for make_hexagon_at_pos...
+#include "ridge_impl/ridge_config.h"   // for RidgeConfig
+#include "ridge_impl/ridge_group.h"    // for RidgeGroup, GroupOf...
+#include "ridge_impl/ridge_mesh.h"     // for RidgeMesh, RidgeHex...
+#include "ridge_impl/ridge_set.h"      // for RidgeSet
+#include "tal/callable.h"              // for Callable
+#include "tal/godot_core.h"            // for D_METHOD, ClassDB
+#include "tal/material.h"              // for ShaderMaterial
+#include "tal/noise.h"                 // for FastNoiseLite
+#include "tal/texture.h"               // for Texture
+#include "tal/vector3.h"               // for Vector3
+#include "tal/vector3i.h"              // for Vector3i
 
 namespace sota {
 

--- a/src/ridge_impl/ridge_hex_grid.h
+++ b/src/ridge_impl/ridge_hex_grid.h
@@ -1,15 +1,20 @@
 #pragma once
 
+#include <map>  // for map
 #include <memory>
-#include <unordered_map>
+#include <unordered_map>  // for unordered_map
+#include <utility>        // for pair
+#include <vector>         // for vector
 
-#include "core/hex_grid.h"
-#include "cube_coordinates.h"
-#include "ridge_impl/ridge_based_object.h"
-#include "ridge_impl/ridge_group.h"
+#include "core/hex_grid.h"  // for HexGrid
+#include "misc/cube_coordinates.h"
+#include "misc/types.h"                     // for Biome, ClipOptions
+#include "ridge_impl/ridge_based_object.h"  // for RidgeBased
+#include "ridge_impl/ridge_group.h"         // for BiomeGroups, GroupOfRidge...
 #include "ridge_impl/ridge_set.h"
-#include "tal/noise.h"
-#include "tal/texture.h"
+#include "tal/noise.h"      // for FastNoiseLite
+#include "tal/reference.h"  // for Ref
+#include "tal/texture.h"    // for Texture
 
 namespace sota {
 

--- a/src/ridge_impl/ridge_mesh.cpp
+++ b/src/ridge_impl/ridge_mesh.cpp
@@ -1,22 +1,25 @@
 #include "ridge_impl/ridge_mesh.h"
 
-#include <algorithm>
-#include <limits>
-#include <set>
-#include <unordered_set>
+#include <algorithm>  // for min, any_of
+#include <iterator>   // for back_insert_it...
+#include <set>        // for set
 
-#include "core/general_utility.h"
-#include "core/utils.h"
-#include "mesh.h"
-#include "misc/utilities.h"
-#include "tal/callable.h"
-#include "tal/godot_core.h"
-#include "tal/vector2.h"
-#include "tal/vector3.h"
-#include "tile_mesh.h"
-#include "types.h"
+#include "core/general_utility.h"  // for MeshProcessor
+#include "core/mesh.h"             // for SotaMesh
+#include "misc/types.h"            // for Neighbours
+#include "misc/utilities.h"        // for to_point_divis...
+#include "primitives/polygon.h"    // for RegularPolygon
+#include "tal/arrays.h"            // for Vector3Array
+#include "tal/callable.h"          // for Callable
+#include "tal/godot_core.h"        // for print
+#include "tal/noise.h"             // for FastNoiseLite
+#include "tal/reference.h"         // for Ref
+#include "tal/vector2.h"           // for Vector2
+#include "tal/vector3.h"           // for Vector3
+#include "tile_mesh.h"             // for TileMesh
 
 namespace sota {
+class Ridge;
 
 void RidgeMesh::_bind_methods() {}
 

--- a/src/ridge_impl/ridge_mesh.h
+++ b/src/ridge_impl/ridge_mesh.h
@@ -1,25 +1,30 @@
 #pragma once
 
-#include <functional>
-#include <limits>
-#include <map>
-#include <memory>
-#include <vector>
+#include <functional>  // for function
+#include <limits>      // for numeric_limits
+#include <map>         // for map
+#include <memory>      // for make_unique, unique_ptr
+#include <set>         // for set
+#include <utility>     // for pair
+#include <vector>      // for vector
 
-#include "core/hex_mesh.h"
-#include "general_utility.h"
-#include "mesh.h"
-#include "misc/types.h"
-#include "pent_mesh.h"
-#include "primitives/pentagon.h"
+#include "core/general_utility.h"  // for FlatMeshProcessor, MeshProc...
+#include "core/hex_mesh.h"         // for HexMeshParams, HexMesh
+#include "core/mesh.h"             // for SotaMesh, Orientation, Orie...
+#include "core/pent_mesh.h"        // for PentagonMeshParams, PentMesh
+#include "core/tile_mesh.h"        // for TileMesh
+#include "core/utils.h"
+#include "misc/types.h"           // for Neighbours, GroupedMeshVert...
+#include "primitives/hexagon.h"   // for Hexagon
+#include "primitives/pentagon.h"  // for Pentagon
 #include "ridge_impl/ridge.h"
-#include "tal/arrays.h"
-#include "tal/noise.h"
-#include "tal/reference.h"
-#include "tal/vector3.h"
-#include "utils.h"
+#include "tal/arrays.h"     // for Vector3Array
+#include "tal/noise.h"      // for FastNoiseLite
+#include "tal/reference.h"  // for Ref
+#include "tal/vector3.h"    // for Vector3
 
 namespace sota {
+class Ridge;
 
 struct RidgeHexMeshParams {
   HexMeshParams hex_mesh_params;

--- a/src/ridge_impl/ridge_set.cpp
+++ b/src/ridge_impl/ridge_set.cpp
@@ -1,17 +1,17 @@
 #include "ridge_set.h"
 
-#include <array>
-#include <random>
+#include <array>    // for array
+#include <memory>   // for allocator_traits<>::value_type
+#include <random>   // for mt19937, uniform_int_distri...
+#include <utility>  // for pair
 
-#include "mesh.h"
-#include "ridge_impl/ridge_config.h"
-#include "ridge_impl/ridge_connection.h"
-#include "ridge_impl/ridge_mesh.h"
-#include "ridge_impl/ridge_set_maker.h"
-#include "tal/godot_core.h"
-#include "tal/vector2.h"
-#include "tal/vector3.h"
-#include "utilities.h"
+#include "core/mesh.h"                    // for SotaMesh
+#include "primitives/polygon.h"           // for RegularPolygon
+#include "ridge_impl/ridge_config.h"      // for RidgeConfig
+#include "ridge_impl/ridge_connection.h"  // for RidgeVertex, RidgeConnection
+#include "ridge_impl/ridge_mesh.h"        // for RidgeMesh
+#include "ridge_impl/ridge_set_maker.h"   // for RidgeSetMaker
+#include "tal/vector3.h"                  // for Vector3
 
 namespace sota {
 

--- a/src/ridge_impl/ridge_set.h
+++ b/src/ridge_impl/ridge_set.h
@@ -1,16 +1,17 @@
 #pragma once
 
 #include <utility>
-#include <vector>
+#include <vector>  // for vector
 
-#include "ridge.h"
-#include "ridge_config.h"
+#include "ridge_impl/ridge.h"         // for Ridge
+#include "ridge_impl/ridge_config.h"  // for RidgeConfig
 #include "tal/vector3.h"
 
 namespace sota {
 
 // TODO remove dependency on RidgeHexMesh
 class RidgeMesh;
+
 class RidgeSet {
  public:
   RidgeSet(RidgeConfig config);

--- a/src/ridge_impl/ridge_set_maker.cpp
+++ b/src/ridge_impl/ridge_set_maker.cpp
@@ -1,15 +1,13 @@
 #include "ridge_set_maker.h"
 
-#include <algorithm>
-#include <random>
-#include <utility>
+#include <algorithm>  // for find, sort
+#include <random>     // for mt19937, uniform_int_distri...
 
-#include "mesh.h"
-#include "misc/types.h"
-#include "ridge_impl/ridge_connection.h"
-#include "ridge_impl/ridge_mesh.h"
-#include "tal/godot_core.h"
-#include "vector3.h"
+#include "core/mesh.h"                    // for SotaMesh
+#include "core/tile_mesh.h"               // for TileMesh
+#include "ridge_impl/ridge_connection.h"  // for RidgeConnection, RidgeVertex
+#include "ridge_impl/ridge_mesh.h"        // for RidgeMesh
+#include "tal/vector3.h"                  // for Vector3
 
 namespace sota {
 

--- a/src/ridge_impl/ridge_set_maker.h
+++ b/src/ridge_impl/ridge_set_maker.h
@@ -1,16 +1,18 @@
 #pragma once
 
-#include <unordered_set>
-#include <vector>
+#include <unordered_set>  // for unordered_set
+#include <vector>         // for vector
 
-#include "ridge.h"
+#include "ridge_impl/ridge.h"  // for Ridge
 #include "ridge_impl/ridge_connection.h"
-#include "ridge_mesh.h"
+#include "ridge_impl/ridge_mesh.h"
 #include "tal/vector3.h"
 
 namespace sota {
 
+class RidgeConnection;
 class RidgeMesh;
+
 using RidgeMeshPointerVector = std::vector<RidgeMesh*>;
 using RidgeVector = std::vector<Ridge>;
 

--- a/src/ridge_impl/water_mesh.h
+++ b/src/ridge_impl/water_mesh.h
@@ -1,7 +1,11 @@
 #pragma once
 
-#include "primitives/pentagon.h"
-#include "ridge_impl/ridge_mesh.h"
+#include <map>      // for map
+#include <utility>  // for pair
+
+#include "primitives/hexagon.h"     // for Hexagon
+#include "primitives/pentagon.h"    // for Pentagon
+#include "ridge_impl/ridge_mesh.h"  // for RidgeMesh, RidgeHexMeshParams
 
 namespace sota {
 


### PR DESCRIPTION
* Apply include-what-you-use to .cpp files via compile database.
  Compilation database created for GDExtension build and <godot_cpp/...>
  includes are manually removed.
* Use path to includes relative to `src/` directory