### PR TITLE
Introduce VertexToNormalsDiscretizer class

### DIFF
--- a/src/core/general_utility.h
+++ b/src/core/general_utility.h
@@ -10,13 +10,14 @@
 #include <utility>     // for pair
 #include <vector>      // for vector
 
-#include "misc/types.h"  // for GroupedMeshVertices
+#include "misc/discretizer.h"
 #include "primitives/polygon.h"
 #include "ridge_impl/ridge.h"
 #include "tal/arrays.h"     // for Vector3Array
 #include "tal/noise.h"      // for FastNoiseLite
 #include "tal/reference.h"  // for Ref
 #include "tal/vector3.h"    // for Vector3
+#include "tal/vector3i.h"
 
 namespace sota {
 class RegularPolygon;
@@ -32,7 +33,7 @@ class MeshProcessor {
   virtual Vector3Array calculate_ridge_based_heights(
       Vector3Array vertices, const RegularPolygon& base, const std::vector<Ridge*> ridges,
       std::vector<Vector3> neighbours_corner_points, float R, std::set<int> exclude_list, float diameter, int divisions,
-      std::map<std::pair<int, int>, float>& distance_keeper, Ref<FastNoiseLite> ridge_noise, float ridge_offset,
+      DiscreteVertexToDistance& distance_map, Ref<FastNoiseLite> ridge_noise, float ridge_offset,
       std::function<double(double, double, double)> interpolation_func, float& min_height, float& max_height) = 0;
 
  private:
@@ -47,7 +48,7 @@ class FlatMeshProcessor : public MeshProcessor {
   Vector3Array calculate_ridge_based_heights(
       Vector3Array vertices, const RegularPolygon& base, const std::vector<Ridge*> ridges,
       std::vector<Vector3> neighbours_corner_points, float R, std::set<int> exclude_list, float diameter, int divisions,
-      std::map<std::pair<int, int>, float>& distance_keeper, Ref<FastNoiseLite> ridge_noise, float ridge_offset,
+      DiscreteVertexToDistance& distance_map, Ref<FastNoiseLite> ridge_noise, float ridge_offset,
       std::function<double(double, double, double)> interpolation_func, float& min_height, float& max_height) override;
 
  private:
@@ -64,7 +65,7 @@ class VolumeMeshProcessor : public MeshProcessor {
   Vector3Array calculate_ridge_based_heights(
       Vector3Array vertices, const RegularPolygon& base, const std::vector<Ridge*> ridges,
       std::vector<Vector3> neighbours_corner_points, float R, std::set<int> exclude_list, float diameter, int divisions,
-      std::map<std::pair<int, int>, float>& distance_keeper, Ref<FastNoiseLite> ridge_noise, float ridge_offset,
+      DiscreteVertexToDistance& distance_map, Ref<FastNoiseLite> ridge_noise, float ridge_offset,
       std::function<double(double, double, double)> interpolation_func, float& min_height, float& max_height) override;
 
  private:
@@ -73,7 +74,7 @@ class VolumeMeshProcessor : public MeshProcessor {
 
 class GeneralUtility {
  public:
-  static void make_smooth_normals(std::vector<GroupedMeshVertices>& vertex_groups);
+  static void make_smooth_normals(std::vector<DiscreteVertexToNormals>& normal_groups);
   static std::pair<std::vector<std::array<float, 3>>, std::vector<float>> get_border_line_coeffs(
       float R, float r, std::set<int> exclude_list);
 };

--- a/src/core/tile_mesh.cpp
+++ b/src/core/tile_mesh.cpp
@@ -1,0 +1,11 @@
+#include "core/tile_mesh.h"
+
+namespace sota {
+
+DiscreteVertexToNormals TileMesh::get_discrete_vertex_to_normals() {
+  auto d = VertexToNormalDiscretizer(inner_mesh()->get_r() / (inner_mesh()->get_divisions() * 2));
+  d.discretize(inner_mesh()->get_vertices(), inner_mesh()->get_normals());
+  return d.get();
+}
+
+}  // namespace sota

--- a/src/core/tile_mesh.h
+++ b/src/core/tile_mesh.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "core/mesh.h"
+#include "misc/discretizer.h"
+#include "misc/types.h"
 #include "tal/reference.h"
 
 namespace sota {
@@ -13,6 +15,8 @@ class TileMesh : public RefCounted {
  public:
   virtual int get_id() = 0;
   virtual SotaMesh* inner_mesh() = 0;
+
+  DiscreteVertexToNormals get_discrete_vertex_to_normals();
 
  protected:
   static void _bind_methods() {}

--- a/src/honeycomb/honeycomb.cpp
+++ b/src/honeycomb/honeycomb.cpp
@@ -406,18 +406,18 @@ void Honeycomb::meshes_update() {
 }
 
 void Honeycomb::calculate_smooth_normals() {
-  std::vector<GroupedMeshVertices> cells_vertex_groups;
+  std::vector<DiscreteVertexToNormals> cells_vertex_groups;
   for (auto& row : _tiles_layout) {
     for (auto& tile_ptr : row) {
       HoneycombCell* mesh = dynamic_cast<HoneycombCell*>(tile_ptr->mesh().ptr());
-      cells_vertex_groups.push_back(mesh->get_grouped_vertices());
+      cells_vertex_groups.push_back(mesh->get_discrete_vertex_to_normals());
     }
   }
-  std::vector<GroupedMeshVertices> honey_vertex_groups;
+  std::vector<DiscreteVertexToNormals> honey_vertex_groups;
   for (auto& row : _tiles_layout) {
     for (auto& tile_ptr : row) {
       HoneycombTile* tile = dynamic_cast<HoneycombTile*>(tile_ptr);
-      honey_vertex_groups.push_back(tile->honey_mesh()->get_grouped_vertices());
+      honey_vertex_groups.push_back(tile->honey_mesh()->get_discrete_vertex_to_normals());
     }
   }
 

--- a/src/honeycomb/honeycomb_cell.cpp
+++ b/src/honeycomb/honeycomb_cell.cpp
@@ -1,8 +1,7 @@
 #include "honeycomb/honeycomb_cell.h"
 
-#include <cmath>  // for abs
-
 #include <algorithm>  // for min
+#include <cmath>      // for abs
 #include <limits>     // for numeric_limits
 #include <utility>    // for tuple_element<...
 #include <vector>     // for vector
@@ -10,6 +9,7 @@
 #include "core/general_utility.h"  // for GeneralUtility
 #include "core/hex_mesh.h"         // for HexMesh
 #include "core/utils.h"            // for cosrp
+#include "misc/discretizer.h"      // for Dicretizer
 #include "misc/types.h"            // for GroupedMeshVer...
 #include "misc/utilities.h"        // for to_point_divis...
 #include "primitives/hexagon.h"    // for Hexagon
@@ -90,21 +90,6 @@ void HoneycombCell::calculate_heights(float bottom_offset) {
     v.y = center.y + cosrp(v.y, approx_end, t(distance_to_border, distance_to_center));
   }
   _hex_mesh->set_vertices(vertices);
-}
-
-// TODO factor out to super-class?
-GroupedMeshVertices HoneycombCell::get_grouped_vertices() {
-  GroupedMeshVertices vertex_groups;
-  auto vertices = _hex_mesh->get_vertices();
-  auto& normals = _hex_mesh->get_normals();
-  int size = vertices.size();
-  for (int i = 0; i < size; ++i) {
-    Vector3 v = vertices[i];
-    Vector3& n = normals[i];
-    auto p = to_point_divisioned_position(v, _hex_mesh->get_R() * 2, _hex_mesh->get_divisions());
-    vertex_groups[p].push_back(&n);
-  }
-  return vertex_groups;
 }
 
 }  // namespace sota

--- a/src/honeycomb/honeycomb_cell.h
+++ b/src/honeycomb/honeycomb_cell.h
@@ -32,7 +32,7 @@ class HoneycombCell : public TileMesh {
   HoneycombCell& operator=(HoneycombCell&& rhs) = delete;
 
   // getters
-  GroupedMeshVertices get_grouped_vertices();
+  int get_id() override { return _hex_mesh->get_id(); }
 
   // setters
   void set_noise(Ref<FastNoiseLite> noise);
@@ -40,7 +40,6 @@ class HoneycombCell : public TileMesh {
 
   void calculate_heights(float bottom_offset);
   HexMesh* inner_mesh() override { return _hex_mesh.ptr(); }
-  int get_id() override { return _hex_mesh->get_id(); }
 
   HoneycombCell(Hexagon hex, HoneycombCellMeshParams params);
 

--- a/src/honeycomb/honeycomb_honey.cpp
+++ b/src/honeycomb/honeycomb_honey.cpp
@@ -7,6 +7,7 @@
 #include "core/general_utility.h"  // for VolumeMeshProc...
 #include "core/hex_mesh.h"         // for HexMesh, HexMe...
 #include "core/mesh.h"             // for Orientation
+#include "misc/discretizer.h"      // for Dicretizer
 #include "misc/types.h"            // for GroupedMeshVer...
 #include "misc/utilities.h"        // for to_point_divis...
 #include "primitives/hexagon.h"    // for Hexagon, make_...
@@ -109,20 +110,6 @@ void HoneycombHoney::calculate_heights() {
   }
   _hex_mesh->set_vertices(
       _processor->shift_compress(_hex_mesh->get_vertices(), _y_shift, _y_compress, _hex_mesh->base().center().y));
-}
-
-GroupedMeshVertices HoneycombHoney::get_grouped_vertices() {
-  GroupedMeshVertices vertex_groups;
-  auto vertices = _hex_mesh->get_vertices();
-  auto& normals = _hex_mesh->get_normals();
-  int size = vertices.size();
-  for (int i = 0; i < size; ++i) {
-    Vector3 v = vertices[i];
-    Vector3& n = normals[i];
-    auto p = to_point_divisioned_position(v, _hex_mesh->get_R() * 2, _hex_mesh->get_divisions());
-    vertex_groups[p].push_back(&n);
-  }
-  return vertex_groups;
 }
 
 void HoneycombHoney::recalculate_vertices_update(float surplus) {

--- a/src/honeycomb/honeycomb_honey.h
+++ b/src/honeycomb/honeycomb_honey.h
@@ -33,7 +33,6 @@ class HoneycombHoney : public TileMesh {
   HoneycombHoney& operator=(HoneycombHoney&& rhs) = delete;
 
   // getters
-  GroupedMeshVertices get_grouped_vertices();
   std::pair<float, float> get_min_max_height() const { return {_min_y, _max_y}; }
 
   // setters

--- a/src/misc/discretizer.cpp
+++ b/src/misc/discretizer.cpp
@@ -1,0 +1,14 @@
+#include "misc/discretizer.h"
+
+#include <cmath>
+
+#include "misc/utilities.h"
+#include "tal/vector3i.h"
+
+namespace sota {
+
+DiscreteVertex VertexToNormalDiscretizer::get_discrete_vertex(Vector3 v, float step) {
+  return DiscreteVertex(std::round(v.x / step), std::round(v.y / step), std::round(v.z / step));
+};
+
+}  // namespace sota

--- a/src/misc/discretizer.h
+++ b/src/misc/discretizer.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <map>
+#include <vector>
+
+#include "tal/arrays.h"
+#include "tal/vector3.h"
+#include "tal/vector3i.h"
+
+namespace sota {
+
+using DiscreteVertex = Vector3i;
+using Distance = float;
+using DiscreteVertexToDistance = std::map<DiscreteVertex, Distance>;
+using DiscreteVertexToNormals = std::map<DiscreteVertex, std::vector<Vector3*>>;
+
+class VertexToNormalDiscretizer {
+ public:
+  VertexToNormalDiscretizer(float step) : _step(step) {}
+
+  static DiscreteVertex get_discrete_vertex(Vector3 v, float step);
+
+  void discretize(Vector3Array vertices, std::vector<Vector3>& normals) {
+    int size = vertices.size();
+    for (int i = 0; i < size; ++i) {
+      Vector3 v = vertices[i];
+      Vector3& n = normals[i];
+      auto p = get_discrete_vertex(v, _step);
+      _discretized[p].push_back(&n);
+    }
+  }
+
+  DiscreteVertexToNormals get() { return _discretized; }
+
+ private:
+  DiscreteVertexToNormals _discretized;
+  float _step;
+};
+}  // namespace sota

--- a/src/misc/types.h
+++ b/src/misc/types.h
@@ -8,13 +8,12 @@
 #include <vector>
 
 #include "tal/vector3.h"
+#include "tal/vector3i.h"
 
 namespace sota {
 
 class TileMesh;
-
 using Neighbours = std::vector<TileMesh*>;
-using GroupedMeshVertices = std::map<std::pair<int, int>, std::vector<Vector3*>>;
 
 enum class Biome { PLAIN = 0, HILL, MOUNTAIN, WATER };
 

--- a/src/misc/utilities.cpp
+++ b/src/misc/utilities.cpp
@@ -10,15 +10,6 @@
 
 namespace sota {
 
-PointDivisionedPosition to_point_divisioned_position(Vector3 v, float diameter, int divisions) {
-  float R = radius(diameter);
-  float r = small_radius(diameter);
-  float z_step = R / (2 * divisions);  // middle vertex of triangle is displaced at half or "R / 2"
-  float x_step = r / divisions;
-
-  return std::make_pair<int, int>(std::round(v.x / x_step), std::round(v.z / z_step));
-};
-
 bool is_water_mesh(TileMesh* mesh) { return dynamic_cast<WaterMesh*>(mesh); }
 bool is_plain_mesh(TileMesh* mesh) { return dynamic_cast<PlainMesh*>(mesh); }
 bool is_hill_mesh(TileMesh* mesh) { return dynamic_cast<HillMesh*>(mesh); }

--- a/src/misc/utilities.h
+++ b/src/misc/utilities.h
@@ -16,10 +16,6 @@
 
 namespace sota {
 
-using PointDivisionedPosition = std::pair<int, int>;
-
-PointDivisionedPosition to_point_divisioned_position(Vector3 v, float diameter, int divisions);
-
 bool is_water_mesh(TileMesh* mesh);
 bool is_plain_mesh(TileMesh* mesh);
 bool is_hill_mesh(TileMesh* mesh);

--- a/src/polyhedron/polyhedron_noise_processor.cpp
+++ b/src/polyhedron/polyhedron_noise_processor.cpp
@@ -89,7 +89,7 @@ void PolyhedronNoiseProcessor::process_meshes(Polyhedron& polyhedron, std::vecto
   for (auto& mesh : meshes) {
     PlainMesh* plain_mesh = dynamic_cast<PlainMesh*>(mesh.ptr());
     float approx_diameter = meshes[0]->inner_mesh()->get_R() * 2;
-    plain_mesh->calculate_final_heights(_distance_keeper, approx_diameter, polyhedron._divisions);
+    plain_mesh->calculate_final_heights(_distance_map, approx_diameter, polyhedron._divisions);
     plain_mesh->recalculate_all_except_vertices();
     plain_mesh->update();
   }

--- a/src/polyhedron/polyhedron_noise_processor.h
+++ b/src/polyhedron/polyhedron_noise_processor.h
@@ -9,6 +9,7 @@
 #include "polyhedron/polyhedron_mesh_processor.h"  // for PolyhedronProcessor
 #include "tal/material.h"                          // for ShaderMaterial
 #include "tal/reference.h"                         // for Ref
+#include "tal/vector3i.h"
 
 namespace sota {
 class Hexagon;
@@ -26,6 +27,6 @@ class PolyhedronNoiseProcessor : public PolyhedronProcessor {
  private:
   void process_meshes(Polyhedron &polyhedron_mesh, std::vector<Ref<TileMesh>> &meshes);
 
-  std::map<std::pair<int, int>, float> _distance_keeper;
+  DiscreteVertexToDistance _distance_map;
 };
 }  // namespace sota

--- a/src/polyhedron/polyhedron_ridge_processor.cpp
+++ b/src/polyhedron/polyhedron_ridge_processor.cpp
@@ -187,11 +187,11 @@ void PolyhedronRidgeProcessor::process_meshes() {
   // print_biomes();
 
   for (RidgeGroup& group : _mountain_groups) {
-    group.init_ridges(_distance_keeper, _ridge_config.top_ridge_offset, _polyhedron_mesh->_divisions);
+    group.init_ridges(_distance_map, _ridge_config.top_ridge_offset, _polyhedron_mesh->_divisions);
   }
 
   for (RidgeGroup& group : _water_groups) {
-    group.init_ridges(_distance_keeper, _ridge_config.bottom_ridge_offset, _polyhedron_mesh->_divisions);
+    group.init_ridges(_distance_map, _ridge_config.bottom_ridge_offset, _polyhedron_mesh->_divisions);
   }
 
   // initial heights calculation
@@ -219,7 +219,7 @@ void PolyhedronRidgeProcessor::process_meshes() {
     RidgeMesh* ridge_mesh = dynamic_cast<RidgeMesh*>(mesh.ptr());
 
     float approx_diameter = _meshes[0]->inner_mesh()->get_R() * 2;
-    ridge_mesh->calculate_final_heights(_distance_keeper, approx_diameter, _polyhedron_mesh->_divisions);
+    ridge_mesh->calculate_final_heights(_distance_map, approx_diameter, _polyhedron_mesh->_divisions);
     ridge_mesh->recalculate_all_except_vertices();
     ridge_mesh->update();
   }

--- a/src/polyhedron/polyhedron_ridge_processor.h
+++ b/src/polyhedron/polyhedron_ridge_processor.h
@@ -15,6 +15,7 @@
 #include "ridge_impl/ridge_set.h"
 #include "tal/material.h"   // for ShaderMaterial
 #include "tal/reference.h"  // for Ref
+#include "tal/vector3i.h"
 
 namespace sota {
 
@@ -42,7 +43,7 @@ class PolyhedronRidgeProcessor : public PolyhedronProcessor, public RidgeBased {
 
   std::vector<Ref<TileMesh>> _meshes;
 
-  std::map<std::pair<int, int>, float> _distance_keeper;
+  DiscreteVertexToDistance _distance_map;
 
   // TODO fix possibility of zero
   float _R_average{0};

--- a/src/ridge_impl/hill_mesh.cpp
+++ b/src/ridge_impl/hill_mesh.cpp
@@ -2,15 +2,15 @@
 
 #include <memory>  // for unique_ptr
 
-#include "core/mesh.h"           // for SotaMesh
-#include "general_utility.h"     // for MeshProcessor
+#include "core/general_utility.h"  // for MeshProcessor
+#include "core/mesh.h"             // for SotaMesh
+#include "misc/discretizer.h"
 #include "primitives/polygon.h"  // for RegularPolygon
 #include "tal/vector3.h"         // for Vector3
 
 namespace sota {
 
-void HillMesh::calculate_final_heights(std::map<std::pair<int, int>, float>& distance_keeper, float diameter,
-                                       int divisions) {
+void HillMesh::calculate_final_heights(DiscreteVertexToDistance& distance_map, float diameter, int divisions) {
   shift_compress();
 
   // TODO add piping for inputs/outputs

--- a/src/ridge_impl/hill_mesh.h
+++ b/src/ridge_impl/hill_mesh.h
@@ -13,8 +13,7 @@ class HillMesh : public RidgeMesh {
  public:
   HillMesh(Hexagon hex, RidgeHexMeshParams params) : RidgeMesh(hex, params) {}
   HillMesh(Pentagon pentagon, RidgePentagonMeshParams params) : RidgeMesh(pentagon, params) {}
-  void calculate_final_heights(std::map<std::pair<int, int>, float>& distance_keeper, float diameter,
-                               int divisions) override;
+  void calculate_final_heights(DiscreteVertexToDistance& distance_map, float diameter, int divisions) override;
 };
 
 }  // namespace sota

--- a/src/ridge_impl/mountain_mesh.cpp
+++ b/src/ridge_impl/mountain_mesh.cpp
@@ -7,10 +7,9 @@ namespace sota {
 // TODO globals
 constexpr float top_y_offset = 0.5;
 
-void MountainMesh::calculate_final_heights(std::map<std::pair<int, int>, float>& distance_keeper, float diameter,
-                                           int divisions) {
+void MountainMesh::calculate_final_heights(DiscreteVertexToDistance& distance_map, float diameter, int divisions) {
   calculate_ridge_based_heights([](double a, double b, double c) { return std::lerp(a, b, c); }, top_y_offset,
-                                distance_keeper, divisions);
+                                distance_map, divisions);
 }
 
 }  // namespace sota

--- a/src/ridge_impl/mountain_mesh.h
+++ b/src/ridge_impl/mountain_mesh.h
@@ -13,8 +13,7 @@ class MountainMesh : public RidgeMesh {
  public:
   MountainMesh(Hexagon hex, RidgeHexMeshParams params) : RidgeMesh(hex, params) {}
   MountainMesh(Pentagon pentagon, RidgePentagonMeshParams params) : RidgeMesh(pentagon, params) {}
-  void calculate_final_heights(std::map<std::pair<int, int>, float>& distance_keeper, float diameter,
-                               int divisions) override;
+  void calculate_final_heights(DiscreteVertexToDistance& distance_map, float diameter, int divisions) override;
 };
 
 }  // namespace sota

--- a/src/ridge_impl/plain_mesh.cpp
+++ b/src/ridge_impl/plain_mesh.cpp
@@ -6,8 +6,7 @@
 
 namespace sota {
 
-void PlainMesh::calculate_final_heights(std::map<std::pair<int, int>, float>& distance_keeper, float diameter,
-                                        int divisions) {
+void PlainMesh::calculate_final_heights(DiscreteVertexToDistance& distance_map, float diameter, int divisions) {
   shift_compress();
   _min_height += _y_shift;
   _min_height *= _y_compress;

--- a/src/ridge_impl/plain_mesh.h
+++ b/src/ridge_impl/plain_mesh.h
@@ -6,6 +6,7 @@
 #include "primitives/hexagon.h"     // for Hexagon
 #include "primitives/pentagon.h"    // for Pentagon
 #include "ridge_impl/ridge_mesh.h"  // for RidgeMesh, RidgeHexMeshParams
+#include "tal/vector3i.h"
 
 namespace sota {
 
@@ -13,8 +14,7 @@ class PlainMesh : public RidgeMesh {
  public:
   PlainMesh(Hexagon hex, RidgeHexMeshParams params) : RidgeMesh(hex, params) {}
   PlainMesh(Pentagon pentagon, RidgePentagonMeshParams params) : RidgeMesh(pentagon, params) {}
-  void calculate_final_heights(std::map<std::pair<int, int>, float>& distance_keeper, float diameter,
-                               int divisions) override;
+  void calculate_final_heights(DiscreteVertexToDistance& distance_map, float diameter, int divisions) override;
 };
 
 }  // namespace sota

--- a/src/ridge_impl/ridge_group.cpp
+++ b/src/ridge_impl/ridge_group.cpp
@@ -5,11 +5,12 @@
 
 #include "ridge_impl/ridge_mesh.h"  // for RidgeMesh
 #include "ridge_impl/ridge_set.h"   // for RidgeSet
+#include "vector3i.h"
 
 namespace sota {
 class Ridge;
 
-void RidgeGroup::init_ridges(std::map<std::pair<int, int>, float>& distance_keeper, float offset, int divisions) {
+void RidgeGroup::init_ridges(DiscreteVertexToDistance& distance_map, float offset, int divisions) {
   if (!_ridge_set) {
     return;
   }
@@ -20,7 +21,7 @@ void RidgeGroup::init_ridges(std::map<std::pair<int, int>, float>& distance_keep
   }
 
   assign_ridges();
-  calculate_corner_points_distances_to_border(distance_keeper, divisions);
+  calculate_corner_points_distances_to_border(distance_map, divisions);
 }
 
 const GroupOfRidgeMeshes& RidgeGroup::meshes() { return _meshes; }
@@ -38,10 +39,9 @@ void RidgeGroup::assign_ridges() {
   }
 }
 
-void RidgeGroup::calculate_corner_points_distances_to_border(std::map<std::pair<int, int>, float>& distance_keeper,
-                                                             int divisions) {
+void RidgeGroup::calculate_corner_points_distances_to_border(DiscreteVertexToDistance& distance_map, int divisions) {
   for (auto* m : _meshes) {
-    m->calculate_corner_points_distances_to_border(distance_keeper, divisions);
+    m->calculate_corner_points_distances_to_border(distance_map, divisions);
   }
 }
 }  // namespace sota

--- a/src/ridge_impl/ridge_group.h
+++ b/src/ridge_impl/ridge_group.h
@@ -32,15 +32,14 @@ class RidgeGroup {
   const GroupOfRidgeMeshes& meshes();
 
   void fmap(std::function<void(const GroupOfRidgeMeshes&)> func);
-  void init_ridges(std::map<std::pair<int, int>, float>& distance_keeper, float offset, int divisions);
+  void init_ridges(DiscreteVertexToDistance& distance_map, float offset, int divisions);
 
  private:
   GroupOfRidgeMeshes _meshes;
   std::optional<std::unique_ptr<RidgeSet>> _ridge_set{};
 
   void assign_ridges();
-  void calculate_corner_points_distances_to_border(std::map<std::pair<int, int>, float>& distance_keeper,
-                                                   int divisions);
+  void calculate_corner_points_distances_to_border(DiscreteVertexToDistance& distance_map, int divisions);
 };
 
 }  // namespace sota

--- a/src/ridge_impl/ridge_hex_grid.cpp
+++ b/src/ridge_impl/ridge_hex_grid.cpp
@@ -333,11 +333,11 @@ void RidgeHexGrid::meshes_update() {
 }
 
 void RidgeHexGrid::calculate_smooth_normals() {
-  std::vector<GroupedMeshVertices> vertex_groups;
+  std::vector<DiscreteVertexToNormals> vertex_groups;
   for (auto& row : _tiles_layout) {
     for (auto& tile_ptr : row) {
       RidgeMesh* mesh = dynamic_cast<RidgeMesh*>(tile_ptr->mesh().ptr());
-      vertex_groups.push_back(mesh->get_grouped_vertices());
+      vertex_groups.push_back(mesh->get_discrete_vertex_to_normals());
     }
   }
 
@@ -414,7 +414,7 @@ void RidgeHexGrid::assign_neighbours(const GroupOfRidgeMeshes& group) {
 
 void RidgeHexGrid::init_ridges(std::vector<RidgeGroup>& group, float ridge_offset) {
   for (RidgeGroup& group : group) {
-    group.init_ridges(_distance_keeper, ridge_offset, _divisions);
+    group.init_ridges(_distance_map, ridge_offset, _divisions);
   }
 }
 
@@ -468,7 +468,7 @@ void RidgeHexGrid::calculate_final_heights() {
     for (auto& tile_ptr : row) {
       RidgeMesh* mesh = dynamic_cast<RidgeMesh*>(tile_ptr->mesh().ptr());
 
-      mesh->calculate_final_heights(_distance_keeper, _diameter, _divisions);
+      mesh->calculate_final_heights(_distance_map, _diameter, _divisions);
       mesh->calculate_normals();
       mesh->update();
     }

--- a/src/ridge_impl/ridge_hex_grid.h
+++ b/src/ridge_impl/ridge_hex_grid.h
@@ -67,7 +67,7 @@ class RidgeHexGrid : public HexGrid, public RidgeBased {
   bool get_smooth_normals() const;
 
  protected:
-  std::map<std::pair<int, int>, float> _distance_keeper;
+  DiscreteVertexToDistance _distance_map;
 
   static void _bind_methods();
 

--- a/src/ridge_impl/ridge_mesh.h
+++ b/src/ridge_impl/ridge_mesh.h
@@ -14,6 +14,7 @@
 #include "core/pent_mesh.h"        // for PentagonMeshParams, PentMesh
 #include "core/tile_mesh.h"        // for TileMesh
 #include "core/utils.h"
+#include "misc/discretizer.h"
 #include "misc/types.h"           // for Neighbours, GroupedMeshVert...
 #include "primitives/hexagon.h"   // for Hexagon
 #include "primitives/pentagon.h"  // for Pentagon
@@ -49,7 +50,6 @@ class RidgeMesh : public TileMesh {
 
   // getters
   std::vector<TileMesh*> get_neighbours() const;
-  GroupedMeshVertices get_grouped_vertices();
   std::pair<float, float> get_min_max_height() const { return {_min_height, _max_height}; }
 
   // setters
@@ -60,11 +60,9 @@ class RidgeMesh : public TileMesh {
   void set_shift_compress(float y_shift, float y_compress);
 
   // calculation
-  void calculate_corner_points_distances_to_border(std::map<std::pair<int, int>, float>& distance_keeper,
-                                                   int divisions);
+  void calculate_corner_points_distances_to_border(DiscreteVertexToDistance& distance_map, int divisions);
   void calculate_initial_heights();
-  virtual void calculate_final_heights(std::map<std::pair<int, int>, float>& distance_keeper, float diameter,
-                                       int divisions) = 0;
+  virtual void calculate_final_heights(DiscreteVertexToDistance& distance_map, float diameter, int divisions) = 0;
 
   void calculate_normals() { _mesh->calculate_normals(); }
   void update() { _mesh->update(); }
@@ -94,8 +92,7 @@ class RidgeMesh : public TileMesh {
 
   void shift_compress();
   void calculate_ridge_based_heights(std::function<double(double, double, double)> interpolation_func,
-                                     float ridge_offset, std::map<std::pair<int, int>, float>& distance_keeper,
-                                     int divisions);
+                                     float ridge_offset, DiscreteVertexToDistance& distance_map, int divisions);
 
   Ref<FastNoiseLite> _plain_noise;
   Ref<FastNoiseLite> _ridge_noise;

--- a/src/ridge_impl/water_mesh.cpp
+++ b/src/ridge_impl/water_mesh.cpp
@@ -7,9 +7,8 @@ namespace sota {
 // TODO globals
 constexpr float bottom_y_offset = 0.5;
 
-void WaterMesh::calculate_final_heights(std::map<std::pair<int, int>, float>& distance_keeper, float diameter,
-                                        int divisions) {
-  calculate_ridge_based_heights(cosrp, bottom_y_offset, distance_keeper, divisions);
+void WaterMesh::calculate_final_heights(DiscreteVertexToDistance& distance_map, float diameter, int divisions) {
+  calculate_ridge_based_heights(cosrp, bottom_y_offset, distance_map, divisions);
 }
 
 }  // namespace sota

--- a/src/ridge_impl/water_mesh.h
+++ b/src/ridge_impl/water_mesh.h
@@ -13,8 +13,7 @@ class WaterMesh : public RidgeMesh {
  public:
   WaterMesh(Hexagon hex, RidgeHexMeshParams params) : RidgeMesh(hex, params) {}
   WaterMesh(Pentagon pentagon, RidgePentagonMeshParams params) : RidgeMesh(pentagon, params) {}
-  void calculate_final_heights(std::map<std::pair<int, int>, float>& distance_keeper, float diameter,
-                               int divisions) override;
+  void calculate_final_heights(DiscreteVertexToDistance& distance_map, float diameter, int divisions) override;
 };
 
 }  // namespace sota


### PR DESCRIPTION
Use it to:
* Make DiscreteVertex from Vector3
* Make mapping from discrete verteces to container of normals. These
  mappings are used to make normals smooth

Also, typedef and rename some badly named classes

Resolves: #43 