### PR TITLE
Collect neighbours at construction of Polyhedron

### DIFF
--- a/src/polyhedron/hex_polyhedron.cpp
+++ b/src/polyhedron/hex_polyhedron.cpp
@@ -4,27 +4,35 @@
 #include <cmath>      // for sqrt, round, cos, sin
 #include <iterator>   // for back_insert_iterator
 #include <limits>     // for numeric_limits
-#include <vector>     // for vector
+#include <memory>
+#include <optional>
+#include <utility>
+#include <vector>
 
-#include "algo/constants.h"         // for PI
-#include "core/godot_utils.h"       // for clean_children
-#include "core/utils.h"             // for map2d_to_3d, ico_in...
+#include "algo/constants.h"    // for PI
+#include "core/godot_utils.h"  // for clean_children
+#include "core/utils.h"        // for map2d_to_3d, ico_in...
+#include "cube_coordinates.h"
+#include "discretizer.h"
 #include "misc/biome_calculator.h"  // for BiomeCalculator
 #include "misc/types.h"             // for Biome, Biome::HILL
-#include "primitives/hexagon.h"     // for Hexagon
-#include "primitives/pentagon.h"    // for Pentagon
-#include "tal/arrays.h"             // for Vector3Array, Array
-#include "tal/callable.h"           // for Callable
-#include "tal/godot_core.h"         // for D_METHOD, ClassDB
-#include "tal/material.h"           // for ShaderMaterial
-#include "tal/noise.h"              // for FastNoiseLite
-#include "tal/shader.h"             // for Shader
-#include "tal/texture.h"            // for Texture
-#include "tal/vector2.h"            // for Vector2
-#include "tal/vector3.h"            // for Vector3
-#include "tal/vector3i.h"           // for Vector3i
+#include "polygon.h"
+#include "primitives/hexagon.h"   // for Hexagon
+#include "primitives/pentagon.h"  // for Pentagon
+#include "tal/arrays.h"           // for Vector3Array, Array
+#include "tal/callable.h"         // for Callable
+#include "tal/godot_core.h"       // for D_METHOD, ClassDB
+#include "tal/material.h"         // for ShaderMaterial
+#include "tal/noise.h"            // for FastNoiseLite
+#include "tal/shader.h"           // for Shader
+#include "tal/texture.h"          // for Texture
+#include "tal/vector2.h"          // for Vector2
+#include "tal/vector3.h"          // for Vector3
+#include "tal/vector3i.h"         // for Vector3i
 
 namespace sota {
+
+int PolygonWrapper::CNT = 0;
 
 Polyhedron::Polyhedron() {
   _texture[Biome::PLAIN] = Ref<Texture>();
@@ -130,9 +138,10 @@ Ref<Texture> Polyhedron::get_water_texture() const { return _texture.find(Biome:
 Ref<Texture> Polyhedron::get_mountain_texture() const { return _texture.find(Biome::MOUNTAIN)->second; }
 
 template <typename TGON>
-void Polyhedron::insert_to_polygons(Vector3 start_point, float diameter, float R, float r, int i, int j,
-                                    Vector3Array icosahedron_points, Vector3i triangle,
-                                    std::map<Vector3i, TGON>& polygons) const {
+std::optional<PolygonWrapper*> Polyhedron::insert_to_polygons(Vector3 start_point, float diameter, float R, float r,
+                                                              int i, int j, Vector3Array icosahedron_points,
+                                                              Vector3i triangle,
+                                                              std::map<Vector3i, PolygonWrapper>& polygons) const {
   float key_step = r / 3.0;
   auto f1 = [](float x) -> float { return sqrt(3) * x + sqrt(3) / 2; };
   auto f2 = [](float x) -> float { return -sqrt(3) * x + sqrt(3) / 2; };
@@ -140,30 +149,35 @@ void Polyhedron::insert_to_polygons(Vector3 start_point, float diameter, float R
 
   Vector3 center(start_point.x + 2 * r * j, 0, start_point.z + diameter * 3.0 * i / 4.0);
   if (i & 1) {
-    center.x -= r;  // offset of odd rows of pent-/hexagons;
+    center.x += r;  // offset of odd rows of pent-/hexagons;
   }
   if ((center.z < -r / 2) || center.z > (f1(center.x) + r / 2) || center.z > (f2(center.x) + r / 2)) {
-    return;  // skip pent-/hexagons out of sample triangle
+    return {};  // skip pent-/hexagons which are out of sample triangle
   }
 
   Vector3 mapped_center = map2d_to_3d(Vector2(center.x, center.z), icosahedron_points[triangle.x],
                                       icosahedron_points[triangle.y], icosahedron_points[triangle.z]);
-  Vector3i key(std::round(mapped_center.x / key_step), std::round(mapped_center.y / key_step),
-               std::round(mapped_center.z / key_step));  // to use dict. due to float fluctuations
+
+  // use discrete values due to float fluctuations
+  DiscreteVertex key = VertexToNormalDiscretizer::get_discrete_vertex(mapped_center, key_step);
+
   if (polygons.find(key) == polygons.end()) {
-    polygons.emplace(key, TGON(mapped_center, mapped_center.normalized()));
+    polygons.insert(
+        std::make_pair(key, PolygonWrapper(std::make_unique<TGON>(mapped_center, mapped_center.normalized()))));
   }
-  TGON& polygon = polygons.find(key)->second;
+  PolygonWrapper& wrapper = polygons.find(key)->second;
+  RegularPolygon* polygon = wrapper.polygon();
   for (float angle = -PI / 6, k = 0; k < 6; k++, angle += PI / 3) {
     Vector3 point(center.x + cos(angle) * R, 0, center.z + sin(angle) * R);
     if (!out_of_triangle(point.x, point.z)) {
-      polygon.add_point(map2d_to_3d(Vector2(point.x, point.z), icosahedron_points[triangle.x],
-                                    icosahedron_points[triangle.y], icosahedron_points[triangle.z]));
+      polygon->add_point(map2d_to_3d(Vector2(point.x, point.z), icosahedron_points[triangle.x],
+                                     icosahedron_points[triangle.y], icosahedron_points[triangle.z]));
     }
   }
+  return &wrapper;
 }
 
-std::pair<std::vector<Hexagon>, std::vector<Pentagon>> Polyhedron::calculate_shapes() const {
+std::pair<std::vector<PolygonWrapper>, std::vector<PolygonWrapper>> Polyhedron::calculate_shapes() const {
   float r = (1.0 / 2) / (_patch_resolution + 1);
   float R = r * 2 / sqrt(3);
   float diameter = 2 * R;
@@ -177,54 +191,83 @@ std::pair<std::vector<Hexagon>, std::vector<Pentagon>> Polyhedron::calculate_sha
             (j == 0 || j == (_patch_resolution + 1)));  // first and last points of first row are centers of pentagon
   };
 
-  std::map<Vector3i, Hexagon> hexagon_map;
-  std::map<Vector3i, Pentagon> pentagon_map;
+  std::map<Vector3i, PolygonWrapper> hexagon_map;
+  std::map<Vector3i, PolygonWrapper> pentagon_map;
+  std::map<CubeCoordinates, PolygonWrapper*> cube_to_discrete_vertex;
   for (int t = 0; t < 20; ++t) {
+    cube_to_discrete_vertex.clear();
     Vector3i triangle = indices[t];
     for (int i = 0; i < _patch_resolution + 2; ++i) {
       for (int j = 0; j < _patch_resolution + 2; ++j) {
+        std::optional<PolygonWrapper*> opt_key;
         if (is_pentagon_ij(i, j)) {
-          insert_to_polygons(start_point, diameter, R, r, i, j, icosahedron_points, triangle, pentagon_map);
+          opt_key = insert_to_polygons<Pentagon>(start_point, diameter, R, r, i, j, icosahedron_points, triangle,
+                                                 pentagon_map);
         } else {
-          insert_to_polygons(start_point, diameter, R, r, i, j, icosahedron_points, triangle, hexagon_map);
+          opt_key =
+              insert_to_polygons<Hexagon>(start_point, diameter, R, r, i, j, icosahedron_points, triangle, hexagon_map);
+        }
+        if (opt_key) {
+          cube_to_discrete_vertex[offsetToCube(OffsetCoordinates{.row = i, .col = j})] = opt_key.value();
+        }
+      }
+    }
+
+    for (auto [cube_coords, wrapper_ptr] : cube_to_discrete_vertex) {
+      for (auto n : neighbours(cube_coords)) {
+        if (cube_to_discrete_vertex.contains(n)) {
+          _neighbours_map[wrapper_ptr->id()].insert(cube_to_discrete_vertex[n]->id());
         }
       }
     }
   }
 
-  std::vector<Hexagon> hexagons;
-  std::transform(hexagon_map.begin(), hexagon_map.end(), std::back_inserter(hexagons),
-                 [](std::pair<Vector3i, Hexagon> p) {
-                   p.second.check();
-                   p.second.sort_points();
-                   return p.second;
-                 });
+  int count_pentagon = 0;
+  for (auto [a, b] : _neighbours_map) {
+    if (b.size() == 5) {
+      ++count_pentagon;
+    } else if (b.size() != 6) {
+      printerr("Condition 'neighbours count == 5 or 6' is not true");
+    }
+  }
+  if (count_pentagon != 12) {
+    printerr("Condition 'pentagon count == 12' is not true");
+  }
 
-  std::vector<Pentagon> pentagons;
-  std::transform(pentagon_map.begin(), pentagon_map.end(), std::back_inserter(pentagons),
-                 [](std::pair<Vector3i, Pentagon> p) {
-                   p.second.check();
-                   p.second.sort_points();
-                   return p.second;
-                 });
+  std::vector<PolygonWrapper> hexagons_wrapped;
+  for (auto it = hexagon_map.begin(); it != hexagon_map.end(); ++it) {
+    PolygonWrapper& wrapper = it->second;
+    wrapper.polygon()->check();
+    wrapper.polygon()->sort_points();
+    hexagons_wrapped.push_back(std::move(wrapper));
+  }
 
-  return std::make_pair(hexagons, pentagons);
+  std::vector<PolygonWrapper> pentagons_wrapped;
+  for (auto it = pentagon_map.begin(); it != pentagon_map.end(); ++it) {
+    PolygonWrapper& wrapper = it->second;
+    wrapper.polygon()->check();
+    wrapper.polygon()->sort_points();
+    pentagons_wrapped.push_back(std::move(wrapper));
+  }
+
+  return std::make_pair(std::move(hexagons_wrapped), std::move(pentagons_wrapped));
 }
 
 void Polyhedron::clear() {
-  _hexagon_meshes.clear();
-  _pentagon_meshes.clear();
+  _hexagons.clear();
+  _pentagons.clear();
+  _neighbours_map.clear();
 
   clean_children(*this);
 }
 
 template <typename T>
-void Polyhedron::process_ngons(std::vector<T> ngons, float min_z, float max_z) {
+void Polyhedron::process_ngons(std::vector<PolygonWrapper>& ngons, float min_z, float max_z) {
   int id = 0;
   std::unordered_map<int, float> altitudes;
-  for (const auto& ngon : ngons) {
+  for (PolygonWrapper& ngon : ngons) {
     if (_biomes_noise.ptr()) {
-      altitudes[id] = _biomes_noise->get_noise_3dv(ngon.center());
+      altitudes[id] = _biomes_noise->get_noise_3dv(ngon.polygon()->center());
     } else {
       altitudes[id] = 0;
     }
@@ -238,7 +281,7 @@ void Polyhedron::process_ngons(std::vector<T> ngons, float min_z, float max_z) {
 
   id = 0;
   BiomeCalculator biome_calculator;
-  for (const auto& ngon : ngons) {
+  for (PolygonWrapper& ngon : ngons) {
     Biome biome = biome_calculator.calculate_biome(min_z, max_z, altitudes[id]);
 
     Ref<ShaderMaterial> mat;
@@ -256,19 +299,25 @@ void Polyhedron::process_ngons(std::vector<T> ngons, float min_z, float max_z) {
 
     set_material_parameters(mat);
 
-    configure_cell(ngon, biome, id, mat);
+    if constexpr (std::is_same_v<T, Hexagon>) {
+      configure_hexagon(ngon, biome, id, mat);
+    } else {
+      configure_pentagon(ngon, biome, id, mat);
+    }
   }
 }
 
 void Polyhedron::init() {
   clear();
 
-  auto [hexagons, pentagons] = calculate_shapes();
+  std::pair<std::vector<PolygonWrapper>, std::vector<PolygonWrapper>> shapes = std::move(calculate_shapes());
+  _hexagons = std::move(shapes.first);
+  _pentagons = std::move(shapes.second);
 
   float min_z = std::numeric_limits<float>::max();
   float max_z = std::numeric_limits<float>::min();
-  process_ngons(hexagons, min_z, max_z);
-  process_ngons(pentagons, min_z, max_z);
+  process_ngons<Hexagon>(_hexagons, min_z, max_z);
+  process_ngons<Pentagon>(_pentagons, min_z, max_z);
 
   process_cells();
   calculate_normals();

--- a/src/polyhedron/noise_polyhedron.h
+++ b/src/polyhedron/noise_polyhedron.h
@@ -1,9 +1,11 @@
 #pragma once
 
+#include "polyhedron/polyhedron_noise_processor.h"
 #include "polyhedron/ridge_based_polyhedron.h"
-#include "polyhedron_noise_processor.h"
 
 namespace sota {
+
+class PolygonWrapper;
 
 class NoisePolyhedron : public RidgeBasedPolyhedron {
   GDCLASS(NoisePolyhedron, RidgeBasedPolyhedron)
@@ -18,11 +20,11 @@ class NoisePolyhedron : public RidgeBasedPolyhedron {
   static void _bind_methods() {}
   void set_material_parameters(Ref<ShaderMaterial> mat) override {}
 
-  void configure_cell(Hexagon hex, Biome biome, int& id, Ref<ShaderMaterial> mat) override {
-    _noise_processor.configure_cell(hex, biome, id, mat, *this);
+  void configure_hexagon(PolygonWrapper& wrapper, Biome biome, int& id, Ref<ShaderMaterial> mat) override {
+    _noise_processor.configure_hexagon(wrapper, biome, id, mat, *this);
   }
-  void configure_cell(Pentagon pentagon, Biome biome, int& id, Ref<ShaderMaterial> mat) override {
-    _noise_processor.configure_cell(pentagon, biome, id, mat, *this);
+  void configure_pentagon(PolygonWrapper& wrapper, Biome biome, int& id, Ref<ShaderMaterial> mat) override {
+    _noise_processor.configure_pentagon(wrapper, biome, id, mat, *this);
   }
 
   void process_cells() override { _noise_processor.process(*this); }

--- a/src/polyhedron/polyhedron_mesh_processor.h
+++ b/src/polyhedron/polyhedron_mesh_processor.h
@@ -9,15 +9,16 @@
 namespace sota {
 
 class Polyhedron;
+class PolygonWrapper;
 
 class PolyhedronProcessor {
  public:
   virtual ~PolyhedronProcessor() = default;
 
-  virtual void configure_cell(Hexagon hex, Biome biome, int &id, Ref<ShaderMaterial> mat,
-                              Polyhedron &polyhedron_mesh) = 0;
-  virtual void configure_cell(Pentagon pentagon, Biome biome, int &id, Ref<ShaderMaterial> mat,
-                              Polyhedron &polyhedron_mesh) = 0;
+  virtual void configure_hexagon(PolygonWrapper &wrapper, Biome biome, int &id, Ref<ShaderMaterial> mat,
+                                 Polyhedron &polyhedron_mesh) = 0;
+  virtual void configure_pentagon(PolygonWrapper &wrapper, Biome biome, int &id, Ref<ShaderMaterial> mat,
+                                  Polyhedron &polyhedron_mesh) = 0;
   virtual void process(Polyhedron &polyhedron_mesh) = 0;
 };
 

--- a/src/polyhedron/polyhedron_noise_processor.h
+++ b/src/polyhedron/polyhedron_noise_processor.h
@@ -19,9 +19,10 @@ class TileMesh;
 
 class PolyhedronNoiseProcessor : public PolyhedronProcessor {
  public:
-  void configure_cell(Hexagon hex, Biome biome, int &id, Ref<ShaderMaterial> mat, Polyhedron &polyhedron_mesh) override;
-  void configure_cell(Pentagon pentagon, Biome biome, int &id, Ref<ShaderMaterial> mat,
-                      Polyhedron &polyhedron_mesh) override;
+  void configure_hexagon(PolygonWrapper &wrapper, Biome biome, int &id, Ref<ShaderMaterial> mat,
+                         Polyhedron &polyhedron_mesh) override;
+  void configure_pentagon(PolygonWrapper &wrapper, Biome biome, int &id, Ref<ShaderMaterial> mat,
+                          Polyhedron &polyhedron_mesh) override;
   void process(Polyhedron &polyhedron_mesh) override;
 
  private:

--- a/src/polyhedron/polyhedron_prism_processor.cpp
+++ b/src/polyhedron/polyhedron_prism_processor.cpp
@@ -20,8 +20,8 @@
 
 namespace sota {
 
-void PolyhedronPrismProcessor::configure_cell(Hexagon hex, Biome biome, int& id, Ref<ShaderMaterial> mat,
-                                              Polyhedron& polyhedron) {
+void PolyhedronPrismProcessor::configure_hexagon(PolygonWrapper& wrapper, Biome biome, int& id, Ref<ShaderMaterial> mat,
+                                                 Polyhedron& polyhedron) {
   auto& prism_polyhedron = dynamic_cast<PrismPolyhedron&>(polyhedron);
   PrismHexMeshParams params{.hex_mesh_params = HexMeshParams{.id = id,
                                                              .material = mat,
@@ -32,16 +32,17 @@ void PolyhedronPrismProcessor::configure_cell(Hexagon hex, Biome biome, int& id,
                             .height = prism_polyhedron._prism_heights[biome]};
 
   auto* mi = memnew(MeshInstance3D());
+  auto& hex = *dynamic_cast<Hexagon*>(wrapper.polygon());
   Ref<PrismHexTile> prism_tile = Ref<PrismHexTile>(memnew(PrismHexTile(hex, params)));
   mi->set_mesh(prism_tile->inner_mesh());
 
   polyhedron.add_child(mi);
-  polyhedron._hexagon_meshes.push_back(prism_tile);
+  wrapper.set_mesh(prism_tile);
   ++id;
 }
 
-void PolyhedronPrismProcessor::configure_cell(Pentagon pentagon, Biome biome, int& id, Ref<ShaderMaterial> mat,
-                                              Polyhedron& polyhedron) {
+void PolyhedronPrismProcessor::configure_pentagon(PolygonWrapper& wrapper, Biome biome, int& id,
+                                                  Ref<ShaderMaterial> mat, Polyhedron& polyhedron) {
   auto& prism_polyhedron = dynamic_cast<PrismPolyhedron&>(polyhedron);
   PrismPentMeshParams params{.pent_mesh_params = PentagonMeshParams{.id = id,
                                                                     .divisions = polyhedron._divisions,
@@ -51,11 +52,12 @@ void PolyhedronPrismProcessor::configure_cell(Pentagon pentagon, Biome biome, in
                              .height = prism_polyhedron._prism_heights[biome]};
 
   auto* mi = memnew(MeshInstance3D());
+  auto& pentagon = *dynamic_cast<Pentagon*>(wrapper.polygon());
   Ref<PrismPentTile> prism_tile = Ref<PrismPentTile>(memnew(PrismPentTile(pentagon, params)));
   mi->set_mesh(prism_tile->inner_mesh());
 
   polyhedron.add_child(mi);
-  polyhedron._pentagon_meshes.push_back(prism_tile);
+  wrapper.set_mesh(prism_tile);
   ++id;
 }
 

--- a/src/polyhedron/polyhedron_prism_processor.h
+++ b/src/polyhedron/polyhedron_prism_processor.h
@@ -12,9 +12,10 @@ class Polyhedron;
 
 class PolyhedronPrismProcessor : public PolyhedronProcessor {
  public:
-  void configure_cell(Hexagon hex, Biome biome, int &id, Ref<ShaderMaterial> mat, Polyhedron &polyhedron_mesh) override;
-  void configure_cell(Pentagon pentagon, Biome biome, int &id, Ref<ShaderMaterial> mat,
-                      Polyhedron &polyhedron_mesh) override;
+  void configure_hexagon(PolygonWrapper &wrapper, Biome biome, int &id, Ref<ShaderMaterial> mat,
+                         Polyhedron &polyhedron_mesh) override;
+  void configure_pentagon(PolygonWrapper &wrapper, Biome biome, int &id, Ref<ShaderMaterial> mat,
+                          Polyhedron &polyhedron_mesh) override;
   void process(Polyhedron &polyhedron_mesh) override;
 };
 

--- a/src/polyhedron/polyhedron_ridge_processor.h
+++ b/src/polyhedron/polyhedron_ridge_processor.h
@@ -32,9 +32,10 @@ class PolyhedronRidgeProcessor : public PolyhedronProcessor, public RidgeBased {
   PolyhedronRidgeProcessor &operator=(const PolyhedronRidgeProcessor &other) = delete;
   PolyhedronRidgeProcessor &operator=(PolyhedronRidgeProcessor &&other) = default;
 
-  void configure_cell(Hexagon hex, Biome biome, int &id, Ref<ShaderMaterial> mat, Polyhedron &polyhedron_mesh) override;
-  void configure_cell(Pentagon pentagon, Biome biome, int &id, Ref<ShaderMaterial> mat,
-                      Polyhedron &polyhedron_mesh) override;
+  void configure_hexagon(PolygonWrapper &wrapper, Biome biome, int &id, Ref<ShaderMaterial> mat,
+                         Polyhedron &polyhedron_mesh) override;
+  void configure_pentagon(PolygonWrapper &wrapper, Biome biome, int &id, Ref<ShaderMaterial> mat,
+                          Polyhedron &polyhedron_mesh) override;
   void process(Polyhedron &polyhedron_mesh) override;
 
   void set_top_offset(float offset) { _ridge_config.top_ridge_offset = offset; }
@@ -46,7 +47,7 @@ class PolyhedronRidgeProcessor : public PolyhedronProcessor, public RidgeBased {
   // TODO fix possibility of zero
   RidgePolyhedron *_polyhedron_mesh;
 
-  std::vector<Ref<TileMesh>> _meshes;
+  std::vector<PolygonWrapper *> _meshes_wrapped;
 
   DiscreteVertexToDistance _distance_map;
 

--- a/src/polyhedron/prism_polyhedron.h
+++ b/src/polyhedron/prism_polyhedron.h
@@ -42,11 +42,11 @@ class PrismPolyhedron : public Polyhedron {
   void calculate_normals() override { /* no need for this for prisms at the moment*/
   }
 
-  void configure_cell(Hexagon hex, Biome biome, int &id, Ref<ShaderMaterial> mat) override {
-    _prism_processor.configure_cell(hex, biome, id, mat, *this);
+  void configure_hexagon(PolygonWrapper& wrapper, Biome biome, int& id, Ref<ShaderMaterial> mat) override {
+    _prism_processor.configure_hexagon(wrapper, biome, id, mat, *this);
   }
-  void configure_cell(Pentagon pentagon, Biome biome, int &id, Ref<ShaderMaterial> mat) override {
-    _prism_processor.configure_cell(pentagon, biome, id, mat, *this);
+  void configure_pentagon(PolygonWrapper& wrapper, Biome biome, int& id, Ref<ShaderMaterial> mat) override {
+    _prism_processor.configure_pentagon(wrapper, biome, id, mat, *this);
   }
 
   void process_cells() override { _prism_processor.process(*this); }

--- a/src/polyhedron/ridge_based_polyhedron.cpp
+++ b/src/polyhedron/ridge_based_polyhedron.cpp
@@ -7,6 +7,7 @@
 #include "core/smooth_shades_processor.h"
 #include "core/tile_mesh.h"
 #include "misc/discretizer.h"
+#include "polyhedron_mesh_processor.h"
 #include "tal/callable.h"    // for Callable
 #include "tal/godot_core.h"  // for D_METHOD, ClassDB
 #include "tal/material.h"    // for ShaderMaterial
@@ -55,10 +56,10 @@ void RidgeBasedPolyhedron::calculate_normals() { SmoothShadesProcessor(meshes())
 
 std::vector<TileMesh*> RidgeBasedPolyhedron::meshes() {
   std::vector<TileMesh*> res;
-  std::transform(_hexagon_meshes.begin(), _hexagon_meshes.end(), std::back_inserter(res),
-                 [](const Ref<TileMesh> mesh) { return mesh.ptr(); });
-  std::transform(_pentagon_meshes.begin(), _pentagon_meshes.end(), std::back_inserter(res),
-                 [](const Ref<TileMesh> mesh) { return mesh.ptr(); });
+  std::transform(_hexagons.begin(), _hexagons.end(), std::back_inserter(res),
+                 [](PolygonWrapper& wrapper) { return wrapper.mesh().ptr(); });
+  std::transform(_pentagons.begin(), _pentagons.end(), std::back_inserter(res),
+                 [](PolygonWrapper& wrapper) { return wrapper.mesh().ptr(); });
   return res;
 }
 

--- a/src/polyhedron/ridge_polyhedron.h
+++ b/src/polyhedron/ridge_polyhedron.h
@@ -5,6 +5,8 @@
 
 namespace sota {
 
+class PolygonWrapper;
+
 class RidgePolyhedron : public RidgeBasedPolyhedron {
   GDCLASS(RidgePolyhedron, RidgeBasedPolyhedron)
  public:
@@ -27,11 +29,11 @@ class RidgePolyhedron : public RidgeBasedPolyhedron {
   static void _bind_methods();
   void set_material_parameters(Ref<ShaderMaterial> mat) override;
 
-  void configure_cell(Hexagon hex, Biome biome, int& id, Ref<ShaderMaterial> mat) override {
-    _ridge_processor.configure_cell(hex, biome, id, mat, *this);
+  void configure_hexagon(PolygonWrapper& wrapper, Biome biome, int& id, Ref<ShaderMaterial> mat) override {
+    _ridge_processor.configure_hexagon(wrapper, biome, id, mat, *this);
   }
-  void configure_cell(Pentagon pentagon, Biome biome, int& id, Ref<ShaderMaterial> mat) override {
-    _ridge_processor.configure_cell(pentagon, biome, id, mat, *this);
+  void configure_pentagon(PolygonWrapper& wrapper, Biome biome, int& id, Ref<ShaderMaterial> mat) override {
+    _ridge_processor.configure_pentagon(wrapper, biome, id, mat, *this);
   }
 
   void process_cells() override { _ridge_processor.process(*this); }

--- a/src/ridge_impl/ridge_mesh.cpp
+++ b/src/ridge_impl/ridge_mesh.cpp
@@ -108,7 +108,6 @@ std::set<int> RidgeMesh::get_exclude_list() {
 void RidgeMesh::calculate_ridge_based_heights(std::function<double(double, double, double)> interpolation_func,
                                               float ridge_offset, DiscreteVertexToDistance& distance_map,
                                               int divisions) {
-  float diameter = _mesh->get_R() * 2;
   shift_compress();
 
   std::vector<Vector3> neighbours_corner_points;
@@ -122,9 +121,11 @@ void RidgeMesh::calculate_ridge_based_heights(std::function<double(double, doubl
   std::set<int> exclude_list = get_exclude_list();
   auto vertices = _mesh->get_vertices();
 
+  float diameter = _mesh->get_R() * 2;
   vertices = _processor->calculate_ridge_based_heights(
       vertices, _mesh->base(), _ridges, neighbours_corner_points, _mesh->get_R(), exclude_list, diameter, divisions,
       distance_map, _ridge_noise, ridge_offset, interpolation_func, _min_height, _max_height);
+
   _mesh->set_vertices(vertices);
 }
 


### PR DESCRIPTION
Use CubeCoordinates to collect neighbours in all of 20 triangular pieces
of Polyhedron. Store neighbours as `int : set<int>` mapping and use it
in RidgePolyhedronProcessor

PolygonWrapper class is created to keep created polygon - hexagon or pentagon,
TileMesh created later by processor and additional fields e.g. id.

#### Fix holes in RidgePolyhedron

Search closest ridge point in vicinity of `2 * ridge_offset` instead of `2 * R`.
Add `printerr` call in case closest ridge point is not found

Resolves #47 