### PR TITLE
Fix Variant to string constructor ambiguity in macos/ios builds

### DIFF
--- a/src/ridge_impl/ridge_based_object.h
+++ b/src/ridge_impl/ridge_based_object.h
@@ -15,16 +15,16 @@ class RidgeBased {
   void print_biomes() {
     print("\n");
     for (RidgeGroup& group : _mountain_groups) {
-      print("Mountain group of size ", group.meshes().size());
+      print("Mountain group of size ", (uint64_t)group.meshes().size());
     }
     for (RidgeGroup& group : _water_groups) {
-      print("Water group of size ", group.meshes().size());
+      print("Water group of size ", (uint64_t)group.meshes().size());
     }
     for (RidgeGroup& group : _hill_groups) {
-      print("Hill group of size ", group.meshes().size());
+      print("Hill group of size ", (uint64_t)group.meshes().size());
     }
     for (RidgeGroup& group : _plain_groups) {
-      print("Plain group of size ", group.meshes().size());
+      print("Plain group of size ", (uint64_t)group.meshes().size());
     }
   }
 


### PR DESCRIPTION
When sending those unsigned long to the stringify function of godot as Variant it will lead to compile error stating an ambiguity as it can't defined which constructor of Variant it should use, happens on macos/ios builds, casting it as uint64_t fixes that and ensure theres always enough space for the value being casted.