### PR TITLE
Advanced terraforming

### DIFF
--- a/project/demo_terrain/demo_terraform/hexagonal_ridge_hex_grid_big.gd
+++ b/project/demo_terrain/demo_terraform/hexagonal_ridge_hex_grid_big.gd
@@ -1,0 +1,32 @@
+extends HexagonalRidgeHexGrid
+
+enum Biome {PLAIN = 0, HILL, MOUNTAIN, WATER}
+
+var terraformer = Terraformer.new()
+
+func _ready() -> void:
+	set_terraformer(terraformer)
+
+
+func _process(_delta: float) -> void:
+	pass
+
+
+func _on_mode_plain_button_pressed() -> void:
+	terraformer.set_biome_to_set(Biome.PLAIN)
+
+
+func _on_mode_hill_button_pressed() -> void:
+	terraformer.set_biome_to_set(Biome.HILL)
+
+
+func _on_mode_mountain_button_pressed() -> void:
+	terraformer.set_biome_to_set(Biome.MOUNTAIN)
+
+
+func _on_mode_water_button_pressed() -> void:
+	terraformer.set_biome_to_set(Biome.WATER)
+
+
+func _on_set_plain_button_hexagonal_big_pressed() -> void:
+	set_biomes("PPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPP", 5)

--- a/project/demo_terrain/demo_terraform/hexagonal_ridge_hex_grid_big.gd.uid
+++ b/project/demo_terrain/demo_terraform/hexagonal_ridge_hex_grid_big.gd.uid
@@ -1,0 +1,1 @@
+uid://bps6w1q3pted1

--- a/project/demo_terrain/demo_terraform/terraform_scene.tscn
+++ b/project/demo_terrain/demo_terraform/terraform_scene.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=17 format=3 uid="uid://d3ua764ah600y"]
+[gd_scene load_steps=18 format=3 uid="uid://d3ua764ah600y"]
 
 [ext_resource type="FastNoiseLite" uid="uid://cgxvojmlhcxha" path="res://demo_terrain/resources/rect_terrain_biomes_noise.tres" id="1_ef2mm"]
 [ext_resource type="FastNoiseLite" uid="uid://b0o4avj71sfcj" path="res://demo_terrain/resources/rect_terrain_plain_noise.tres" id="2_bp2s3"]
@@ -13,6 +13,7 @@
 [ext_resource type="FastNoiseLite" uid="uid://d4lduvo2g6nuv" path="res://demo_terrain/resources/hex_terrain_plain_noise.tres" id="11_p3rrt"]
 [ext_resource type="FastNoiseLite" uid="uid://c4332g4a8o75g" path="res://demo_terrain/resources/hex_terrain_mountain_noise.tres" id="12_n0cpy"]
 [ext_resource type="Script" uid="uid://bwgx0m7a1xmfm" path="res://demo_terrain/demo_terraform/hexagonal_ridge_hex_grid.gd" id="13_02odl"]
+[ext_resource type="Script" uid="uid://bps6w1q3pted1" path="res://demo_terrain/demo_terraform/hexagonal_ridge_hex_grid_big.gd" id="14_26pbl"]
 
 [sub_resource type="ProceduralSkyMaterial" id="ProceduralSkyMaterial_btloy"]
 sky_horizon_color = Color(0.64625, 0.65575, 0.67075, 1)
@@ -36,24 +37,12 @@ environment = SubResource("Environment_h55sa")
 transform = Transform3D(-0.866024, -0.433016, 0.250001, -0.290297, 0.842538, 0.453715, -0.407101, 0.320353, -0.855361, 0, 3.65866, -9.7787)
 shadow_enabled = true
 
-[node name="set_plain_button_rectangular" type="Button" parent="."]
-anchors_preset = -1
-anchor_left = 0.595
-anchor_top = 0.904
-anchor_right = 0.83
-anchor_bottom = 0.997
-offset_left = 0.559937
-offset_top = 0.207947
-offset_right = -0.160034
-offset_bottom = -0.0559692
-text = "Rectangular terrain: set all Plain"
-
 [node name="Camera3D" type="Camera3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, 0.450099, 0.892979, 0, -0.892979, 0.450099, 0.287141, 3.91961, 3.73948)
+transform = Transform3D(1, 0, 0, 0, 0.450099, 0.892979, 0, -0.892979, 0.450099, 0.287141, 6.8768, 4.27075)
 
-[node name="RectRidgeHexGrid" type="RectRidgeHexGrid" parent="."]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 1.16062, 0, 0)
-_shader = ExtResource("8_k1okd")
+[node name="RectRidgeHexGrid_small" type="RectRidgeHexGrid" parent="."]
+_height = 4
+_width = 4
 noise_biomes = ExtResource("1_ef2mm")
 noise_plain_hill = ExtResource("2_bp2s3")
 noise_mountain_water = ExtResource("3_803qo")
@@ -61,13 +50,12 @@ texture_plain = ExtResource("4_43mri")
 texture_hill = ExtResource("5_7hnnf")
 texture_water = ExtResource("6_1raos")
 texture_mountain = ExtResource("7_am2ly")
-_height = 4
-_width = 4
+_shader = ExtResource("8_k1okd")
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 6.13443, 0, -1.15899)
 script = ExtResource("9_f7061")
 
-[node name="HexagonalRidgeHexGrid" type="HexagonalRidgeHexGrid" parent="."]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -4.2908, 0, -0.382719)
-_shader = ExtResource("8_k1okd")
+[node name="HexagonalRidgeHexGrid_small" type="HexagonalRidgeHexGrid" parent="."]
+_size = 2
 noise_biomes = ExtResource("10_xb5yc")
 noise_plain_hill = ExtResource("11_p3rrt")
 noise_mountain_water = ExtResource("12_n0cpy")
@@ -75,8 +63,22 @@ texture_plain = ExtResource("4_43mri")
 texture_hill = ExtResource("5_7hnnf")
 texture_water = ExtResource("6_1raos")
 texture_mountain = ExtResource("7_am2ly")
-_size = 2
+_shader = ExtResource("8_k1okd")
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -9.3851, 0, -1.62392)
 script = ExtResource("13_02odl")
+
+[node name="HexagonalRidgeHexGrid_big" type="HexagonalRidgeHexGrid" parent="."]
+_size = 5
+noise_biomes = ExtResource("10_xb5yc")
+noise_plain_hill = ExtResource("11_p3rrt")
+noise_mountain_water = ExtResource("12_n0cpy")
+texture_plain = ExtResource("4_43mri")
+texture_hill = ExtResource("5_7hnnf")
+texture_water = ExtResource("6_1raos")
+texture_mountain = ExtResource("7_am2ly")
+_shader = ExtResource("8_k1okd")
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -4.6428, 0, -3.93709)
+script = ExtResource("14_26pbl")
 
 [node name="mode_plain_button" type="Button" parent="."]
 anchors_preset = -1
@@ -127,25 +129,54 @@ offset_right = 0.104004
 offset_bottom = 0.216003
 text = "Mode: water"
 
-[node name="Button" type="Button" parent="."]
+[node name="set_plain_button_hexagonal_small" type="Button" parent="."]
 anchors_preset = -1
-anchor_left = 0.15
+anchor_left = 0.072
 anchor_top = 0.904
-anchor_right = 0.385
+anchor_right = 0.204
 anchor_bottom = 0.997
-offset_left = 0.199997
+offset_left = 0.0559921
 offset_top = 0.207947
-offset_right = -0.519989
-offset_bottom = -0.0559692
-text = "Hexagonal terrain: set all Plain"
+offset_right = -0.00801086
+offset_bottom = -0.0560303
+text = "Hex small: plain"
 
-[connection signal="pressed" from="set_plain_button_rectangular" to="RectRidgeHexGrid" method="_on_button_pressed"]
-[connection signal="pressed" from="mode_plain_button" to="RectRidgeHexGrid" method="_on_mode_plain_button_pressed"]
-[connection signal="pressed" from="mode_plain_button" to="HexagonalRidgeHexGrid" method="_on_mode_plain_button_pressed"]
-[connection signal="pressed" from="mode_hill_button" to="RectRidgeHexGrid" method="_on_mode_hill_button_pressed"]
-[connection signal="pressed" from="mode_hill_button" to="HexagonalRidgeHexGrid" method="_on_mode_hill_button_pressed"]
-[connection signal="pressed" from="mode_mountain_button" to="RectRidgeHexGrid" method="_on_mode_mountain_button_pressed"]
-[connection signal="pressed" from="mode_mountain_button" to="HexagonalRidgeHexGrid" method="_on_mode_mountain_button_pressed"]
-[connection signal="pressed" from="mode_water_button" to="RectRidgeHexGrid" method="_on_mode_water_button_pressed"]
-[connection signal="pressed" from="mode_water_button" to="HexagonalRidgeHexGrid" method="_on_mode_water_button_pressed"]
-[connection signal="pressed" from="Button" to="HexagonalRidgeHexGrid" method="_on_button_pressed"]
+[node name="set_plain_button_rectangular_small" type="Button" parent="."]
+anchors_preset = -1
+anchor_left = 0.8
+anchor_top = 0.903
+anchor_right = 0.967
+anchor_bottom = 0.997
+offset_left = 0.399963
+offset_top = -0.144043
+offset_right = 0.0158691
+offset_bottom = -1.05597
+text = "Rect small: plain"
+
+[node name="set_plain_button_hexagonal_big" type="Button" parent="."]
+anchors_preset = -1
+anchor_left = 0.072
+anchor_top = 0.904
+anchor_right = 0.204
+anchor_bottom = 0.997
+offset_left = 413.056
+offset_top = 0.207947
+offset_right = 412.992
+offset_bottom = -0.0560303
+text = "Hex big: plain"
+
+[connection signal="pressed" from="mode_plain_button" to="RectRidgeHexGrid_small" method="_on_mode_plain_button_pressed"]
+[connection signal="pressed" from="mode_plain_button" to="HexagonalRidgeHexGrid_small" method="_on_mode_plain_button_pressed"]
+[connection signal="pressed" from="mode_plain_button" to="HexagonalRidgeHexGrid_big" method="_on_mode_plain_button_pressed"]
+[connection signal="pressed" from="mode_hill_button" to="RectRidgeHexGrid_small" method="_on_mode_hill_button_pressed"]
+[connection signal="pressed" from="mode_hill_button" to="HexagonalRidgeHexGrid_small" method="_on_mode_hill_button_pressed"]
+[connection signal="pressed" from="mode_hill_button" to="HexagonalRidgeHexGrid_big" method="_on_mode_hill_button_pressed"]
+[connection signal="pressed" from="mode_mountain_button" to="RectRidgeHexGrid_small" method="_on_mode_mountain_button_pressed"]
+[connection signal="pressed" from="mode_mountain_button" to="HexagonalRidgeHexGrid_small" method="_on_mode_mountain_button_pressed"]
+[connection signal="pressed" from="mode_mountain_button" to="HexagonalRidgeHexGrid_big" method="_on_mode_mountain_button_pressed"]
+[connection signal="pressed" from="mode_water_button" to="RectRidgeHexGrid_small" method="_on_mode_water_button_pressed"]
+[connection signal="pressed" from="mode_water_button" to="HexagonalRidgeHexGrid_small" method="_on_mode_water_button_pressed"]
+[connection signal="pressed" from="mode_water_button" to="HexagonalRidgeHexGrid_big" method="_on_mode_water_button_pressed"]
+[connection signal="pressed" from="set_plain_button_hexagonal_small" to="HexagonalRidgeHexGrid_small" method="_on_button_pressed"]
+[connection signal="pressed" from="set_plain_button_rectangular_small" to="RectRidgeHexGrid_small" method="_on_button_pressed"]
+[connection signal="pressed" from="set_plain_button_hexagonal_big" to="HexagonalRidgeHexGrid_big" method="_on_set_plain_button_hexagonal_big_pressed"]

--- a/project/demo_terrain/flat_terrain_scene.tscn
+++ b/project/demo_terrain/flat_terrain_scene.tscn
@@ -31,34 +31,34 @@ render_priority = 0
 shader = ExtResource("1_pum5v")
 
 [sub_resource type="PentMesh" id="PentMesh_57ooj"]
-material = SubResource("ShaderMaterial_2toje")
 divisions = 3
+material = SubResource("ShaderMaterial_2toje")
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_djkpx"]
 render_priority = 0
 shader = ExtResource("1_pum5v")
 
 [sub_resource type="HexMesh" id="HexMesh_i6ufk"]
-material = SubResource("ShaderMaterial_djkpx")
 divisions = 2
+material = SubResource("ShaderMaterial_djkpx")
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_g7q1k"]
 render_priority = 0
 shader = ExtResource("1_pum5v")
 
 [sub_resource type="PrismHexMesh" id="PrismHexMesh_cf0jy"]
-material = SubResource("ShaderMaterial_g7q1k")
-divisions = 2
 height = 0.835
+divisions = 2
+material = SubResource("ShaderMaterial_g7q1k")
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_ineyc"]
 render_priority = 0
 shader = ExtResource("1_pum5v")
 
 [sub_resource type="PrismPentMesh" id="PrismPentMesh_86pmr"]
-material = SubResource("ShaderMaterial_ineyc")
-divisions = 2
 height = 0.85
+divisions = 2
+material = SubResource("ShaderMaterial_ineyc")
 
 [node name="Node3D" type="Node3D"]
 
@@ -80,8 +80,8 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -5, 0, 5)
 mesh = SubResource("HexMesh_i6ufk")
 
 [node name="RectRidgeHexGrid" type="RectRidgeHexGrid" parent="."]
-_divisions = 7
-_shader = ExtResource("6_8c8ug")
+_height = 7
+_width = 7
 _smooth_normals = true
 noise_biomes = ExtResource("7_pdqbd")
 noise_plain_hill = ExtResource("8_tlppm")
@@ -90,13 +90,11 @@ texture_plain = ExtResource("2_diq8e")
 texture_hill = ExtResource("3_dt225")
 texture_water = ExtResource("4_0msuc")
 texture_mountain = ExtResource("5_l3sdd")
-_height = 7
-_width = 7
-
-[node name="HexagonalRidgeHexGrid" type="HexagonalRidgeHexGrid" parent="."]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 7)
 _divisions = 7
 _shader = ExtResource("6_8c8ug")
+
+[node name="HexagonalRidgeHexGrid" type="HexagonalRidgeHexGrid" parent="."]
+_size = 3
 _smooth_normals = true
 noise_biomes = ExtResource("2_w71nt")
 noise_plain_hill = ExtResource("3_rgrq2")
@@ -105,27 +103,29 @@ texture_plain = ExtResource("2_diq8e")
 texture_hill = ExtResource("3_dt225")
 texture_water = ExtResource("4_0msuc")
 texture_mountain = ExtResource("5_l3sdd")
-_size = 3
+_divisions = 7
+_shader = ExtResource("6_8c8ug")
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 7)
 
 [node name="RectHexGrid_minimal" type="RectHexGrid" parent="."]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -3.76043, -9.53674e-07, 3.01861)
+_height = 1
+width = 1
 _shader = ExtResource("1_pum5v")
 enable_frame = true
 _frame_offset = 0.545
-_height = 1
-width = 1
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -3.76043, -9.53674e-07, 3.01861)
 
 [node name="HexagonalHexGrid" type="HexagonalHexGrid" parent="."]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 8, 0, 7)
-_shader = ExtResource("1_pum5v")
 _size = 3
+_shader = ExtResource("1_pum5v")
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 8, 0, 7)
 
 [node name="RectHexGrid" type="RectHexGrid" parent="."]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 8.30717, 0, 0)
-_shader = ExtResource("1_pum5v")
-enable_frame = true
 _height = 7
 width = 7
+_shader = ExtResource("1_pum5v")
+enable_frame = true
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 8.30717, 0, 0)
 
 [node name="PrismHexMesh_instance" type="MeshInstance3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 8.09963, 0, 6.43768)

--- a/src/core/hex_grid.h
+++ b/src/core/hex_grid.h
@@ -60,7 +60,7 @@ class HexGrid : public Node3D {
 
   virtual void init_col_row_layout() = 0;
   virtual void make_tiles();
-  std::map<CubeCoordinates, TileMesh*> _cube_to_hexagon;
+  std::map<CubeCoordinates, TileMesh*> _cube_coord_to_tile_mesh;
 
   bool _frame_state{false};
   float _frame_offset{0.0};

--- a/src/misc/tile.cpp
+++ b/src/misc/tile.cpp
@@ -4,8 +4,8 @@
 #include "honeycomb/honeycomb_honey.h"
 #include "misc/cube_coordinates.h"
 #include "misc/types.h"
-#include "ridge_mesh.h"
 #include "ridge_impl/ridge_hex_grid.h"
+#include "ridge_mesh.h"
 #include "tal/callable.h"
 #include "tal/engine.h"
 #include "tal/event.h"
@@ -69,8 +69,12 @@ void BiomeTile::_bind_methods() {
 }
 
 void BiomeTile::handle_mouse_entered() {
-  // placeholder
+  if (Input::get_singleton()->is_mouse_button_pressed(MOUSE_BUTTON_LEFT)) {
+    auto* ridge_hex_grid_parent = dynamic_cast<RidgeHexGrid*>(get_parent());
+    ridge_hex_grid_parent->process_tile(_row, _col);
+  }
 }
+
 void BiomeTile::handle_mouse_exited() {
   // placeholder
 }

--- a/src/misc/tile.h
+++ b/src/misc/tile.h
@@ -11,6 +11,7 @@
 #include "tal/mesh.h"
 #include "tal/node.h"
 #include "tal/reference.h"
+#include "tile_mesh.h"
 
 namespace sota {
 
@@ -35,6 +36,14 @@ class Tile : public Node3D {
   void destroy() {
     get_parent()->remove_child(this);
     this->queue_free();
+  }
+
+  void replace_mesh(Ref<TileMesh> new_mesh) {
+    _mesh = new_mesh;
+    auto points = new_mesh->inner_mesh()->base().points();
+    auto center = new_mesh->inner_mesh()->base().center();
+    _sphere_shaped3d->set_radius(center.distance_to(points[0]));
+    _main_mesh_instance->set_mesh(new_mesh->inner_mesh());
   }
 
  protected:

--- a/src/misc/types.cpp
+++ b/src/misc/types.cpp
@@ -1,3 +1,23 @@
 #include "misc/types.h"
 
-namespace sota {}  // namespace sota
+#include "tal/godot_core.h"
+
+namespace sota {
+
+std::string biome_to_string(Biome biome) {
+  switch (biome) {
+    case Biome::PLAIN:
+      return "plain";
+    case Biome::HILL:
+      return "hill";
+    case Biome::MOUNTAIN:
+      return "mountain";
+    case Biome::WATER:
+      return "water";
+  }
+
+  printerr("can't convert Biome to string");  // should be never reached
+  return "unreachable code";
+}
+
+}  // namespace sota

--- a/src/misc/types.h
+++ b/src/misc/types.h
@@ -17,6 +17,8 @@ using Neighbours = std::vector<TileMesh*>;
 
 enum class Biome { PLAIN = 0, HILL, MOUNTAIN, WATER };
 
+std::string biome_to_string(Biome biome);
+
 struct ClipOptions {
   bool left{false};
   bool right{false};

--- a/src/polyhedron/polyhedron_ridge_processor.cpp
+++ b/src/polyhedron/polyhedron_ridge_processor.cpp
@@ -160,13 +160,13 @@ void PolyhedronRidgeProcessor::init_biomes() {
     Biome biome = opt_biome.value();
     dfs(wrapper->mesh().ptr(), cur_group, visited, biome);
     if (biome == Biome::PLAIN) {
-      _plain_groups.emplace_back(cur_group);
+      _plain_groups.emplace_back(cur_group, Biome::PLAIN);
     } else if (biome == Biome::HILL) {
-      _hill_groups.emplace_back(cur_group);
+      _hill_groups.emplace_back(cur_group, Biome::HILL);
     } else if (biome == Biome::WATER) {
-      _water_groups.emplace_back(cur_group, std::make_unique<RidgeSet>(_ridge_config));
+      _water_groups.emplace_back(cur_group, std::make_unique<RidgeSet>(_ridge_config), Biome::WATER);
     } else if (biome == Biome::MOUNTAIN) {
-      _mountain_groups.emplace_back(cur_group, std::make_unique<RidgeSet>(_ridge_config));
+      _mountain_groups.emplace_back(cur_group, std::make_unique<RidgeSet>(_ridge_config), Biome::MOUNTAIN);
     }
   }
 }

--- a/src/ridge_impl/ridge_based_object.h
+++ b/src/ridge_impl/ridge_based_object.h
@@ -7,6 +7,7 @@
 #include "ridge.h"
 #include "ridge_impl/ridge_group.h"
 #include "tal/godot_core.h"
+#include "types.h"
 
 namespace sota {
 
@@ -42,6 +43,21 @@ class RidgeBased {
     res.insert(res.end(), _plain_groups.begin(), _plain_groups.end());
     res.insert(res.end(), _hill_groups.begin(), _hill_groups.end());
     return res;
+  }
+
+  std::vector<RidgeGroup>& get_groups_by_biome(Biome biome) {
+    switch (biome) {
+      case Biome::PLAIN:
+        return _plain_groups;
+      case Biome::HILL:
+        return _hill_groups;
+      case Biome::MOUNTAIN:
+        return _mountain_groups;
+      case Biome::WATER:
+        return _water_groups;
+      default:
+        printerr("Unknown biome in get_groups_by_biome");  // should be never reached
+    }
   }
 
  protected:

--- a/src/ridge_impl/ridge_group.cpp
+++ b/src/ridge_impl/ridge_group.cpp
@@ -1,10 +1,18 @@
 #include "ridge_impl/ridge_group.h"
 
 #include <algorithm>  // for transform
-#include <iterator>   // for back_insert_iterator, back_inserter
+#include <cassert>
+#include <cstddef>
+#include <iterator>  // for back_insert_iterator, back_inserter
+#include <memory>
+#include <numeric>
+#include <unordered_set>
 
+#include "ridge_config.h"
 #include "ridge_impl/ridge_mesh.h"  // for RidgeMesh
 #include "ridge_impl/ridge_set.h"   // for RidgeSet
+#include "tile_mesh.h"
+#include "types.h"
 #include "vector3i.h"
 
 namespace sota {
@@ -27,6 +35,7 @@ void RidgeGroup::init_ridges(DiscreteVertexToDistance& distance_map, float offse
 const GroupOfRidgeMeshes& RidgeGroup::meshes() { return _meshes; }
 
 void RidgeGroup::fmap(std::function<void(const GroupOfRidgeMeshes&)> func) { func(_meshes); }
+void RidgeGroup::fmap_mutable(std::function<void(GroupOfRidgeMeshes&)> func) { func(_meshes); }
 
 void RidgeGroup::assign_ridges() {
   auto* ridges = _ridge_set.value()->ridges();
@@ -44,4 +53,80 @@ void RidgeGroup::calculate_corner_points_distances_to_border(DiscreteVertexToDis
     m->calculate_corner_points_distances_to_border(distance_map, divisions);
   }
 }
+
+bool check_biomes(std::vector<RidgeGroup*>& groups) {
+  if (groups.empty()) {
+    return true;
+  }
+  Biome biome_of_first_group = groups[0]->biome();
+  return std::all_of(groups.begin(), groups.end(),
+                     [biome_of_first_group](RidgeGroup* group) { return group->biome() == biome_of_first_group; });
+}
+
+std::optional<RidgeGroup> combine(std::vector<RidgeGroup*> groups, RidgeConfig config) {
+  if (groups.empty()) {
+    return {};
+  }
+  if (!check_biomes(groups)) {
+    return {};
+  }
+  size_t new_size = std::accumulate(groups.begin(), groups.end(), 0,
+                                    [](size_t acc, const RidgeGroup* group) { return group->size(); });
+
+  GroupOfRidgeMeshes res;
+  res.reserve(new_size);
+  for (auto* group : groups) {
+    res.insert(res.cend(), group->_meshes.begin(), group->_meshes.end());
+  }
+  return (*groups.begin())->_ridge_set.has_value()
+             ? RidgeGroup(res, std::make_unique<RidgeSet>(config), groups[0]->biome())
+             : RidgeGroup(res, groups[0]->biome());
+}
+
+void subtract(std::vector<RidgeGroup>& base, std::vector<RidgeGroup*> removed) {
+  for (RidgeGroup* group_to_be_removed : removed) {
+    auto pred = [group_to_be_removed](const RidgeGroup& group) { return std::addressof(group) == group_to_be_removed; };
+
+    size_t erased_num = std::erase_if(base, pred);
+    assert(erased_num == 1);
+  }
+}
+
+static void dfs(RidgeMesh* current, GroupOfRidgeMeshes& ridge_meshed_to_add, std::unordered_set<RidgeMesh*>& visited) {
+  if (visited.contains(current)) {
+    return;
+  }
+  visited.insert(current);
+  ridge_meshed_to_add.push_back(current);
+  for (TileMesh* tile_mesh : current->get_neighbours()) {
+    RidgeMesh* ridge_mesh = dynamic_cast<RidgeMesh*>(tile_mesh);
+    dfs(ridge_mesh, ridge_meshed_to_add, visited);
+  }
+}
+
+std::vector<RidgeGroup> remove_mesh(RidgeGroup& ridge_group, RidgeMesh* mesh, RidgeConfig config) {
+  Biome biome = ridge_group.biome();
+  for (TileMesh* tile_mesh : mesh->get_neighbours()) {
+    RidgeMesh* neighbour = dynamic_cast<RidgeMesh*>(tile_mesh);
+    neighbour->remove_neighbour(mesh);
+  }
+  std::vector<RidgeGroup> res;
+  std::unordered_set<RidgeMesh*> visited;
+  for (RidgeMesh* ridge_mesh : ridge_group._meshes) {
+    GroupOfRidgeMeshes ridge_meshed_to_add;
+    if (ridge_mesh == mesh || visited.contains(ridge_mesh)) {
+      continue;
+    }
+    dfs(ridge_mesh, ridge_meshed_to_add, visited);
+    RidgeGroup new_group = ridge_group._ridge_set.has_value()
+                               ? RidgeGroup(ridge_meshed_to_add, std::make_unique<RidgeSet>(config), biome)
+                               : RidgeGroup(ridge_meshed_to_add, biome);
+    res.emplace_back(std::move(new_group));
+  }
+
+  assert(1 <= res.size() && res.size() <= 3);
+
+  return res;
+}
+
 }  // namespace sota

--- a/src/ridge_impl/ridge_group.h
+++ b/src/ridge_impl/ridge_group.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <functional>  // for function
 #include <map>         // for map
 #include <memory>      // for unique_ptr
@@ -7,8 +8,11 @@
 #include <utility>     // for move, pair
 #include <vector>      // for vector
 
+#include "ridge.h"
+#include "ridge_config.h"
 #include "ridge_impl/ridge_mesh.h"
 #include "ridge_impl/ridge_set.h"  // for RidgeSet
+#include "types.h"
 
 namespace sota {
 class RidgeMesh;
@@ -18,9 +22,9 @@ using BiomeGroups = std::vector<GroupOfRidgeMeshes>;
 
 class RidgeGroup {
  public:
-  RidgeGroup(GroupOfRidgeMeshes meshes, std::unique_ptr<RidgeSet> ridge_set)
-      : _meshes(meshes), _ridge_set(std::move(ridge_set)) {}
-  RidgeGroup(GroupOfRidgeMeshes meshes) : _meshes(meshes), _ridge_set({}) {}
+  RidgeGroup(GroupOfRidgeMeshes meshes, std::unique_ptr<RidgeSet> ridge_set, Biome biome)
+      : _meshes(meshes), _ridge_set(std::move(ridge_set)), _biome(biome) {}
+  explicit RidgeGroup(GroupOfRidgeMeshes meshes, Biome biome) : _meshes(meshes), _ridge_set({}), _biome(biome) {}
 
   RidgeGroup() = default;
   RidgeGroup(const RidgeGroup& other) = delete;
@@ -32,14 +36,38 @@ class RidgeGroup {
   const GroupOfRidgeMeshes& meshes();
 
   void fmap(std::function<void(const GroupOfRidgeMeshes&)> func);
+  void fmap_mutable(std::function<void(GroupOfRidgeMeshes&)> func);
   void init_ridges(DiscreteVertexToDistance& distance_map, float offset, int divisions);
+  bool has(RidgeMesh* mesh) { return std::find(_meshes.begin(), _meshes.end(), mesh) != _meshes.end(); }
+  bool has_ridge_set() const { return _ridge_set.has_value(); };
+  size_t size() const { return _meshes.size(); }
+  Biome biome() { return _biome; }
+
+  void add(RidgeMesh* mesh) { _meshes.push_back(mesh); }
 
  private:
+  friend std::optional<RidgeGroup> combine(std::vector<RidgeGroup*> groups, RidgeConfig config);
+  friend std::vector<RidgeGroup> remove_mesh(RidgeGroup& ridge_group, RidgeMesh* mesh, RidgeConfig config);
+
   GroupOfRidgeMeshes _meshes;
+  Biome _biome;
   std::optional<std::unique_ptr<RidgeSet>> _ridge_set{};
 
   void assign_ridges();
   void calculate_corner_points_distances_to_border(DiscreteVertexToDistance& distance_map, int divisions);
 };
+
+bool check_biomes(std::vector<RidgeGroup>& groups);
+
+// Return new RidgeGroup based on multiple RidgeGroup's.
+std::optional<RidgeGroup> combine(std::vector<RidgeGroup*> groups, RidgeConfig config);
+
+// If vector of RidgeGroup's is given remove specific RidgeGroups from it if that pointer to it is present in
+// 'groups_to_be_removed' vector
+void subtract(std::vector<RidgeGroup>& base, std::vector<RidgeGroup*> removed);
+
+// If RidgeGroup is given return vector of RidgeGroups which are formed by removal of specific RidgeMesh from original
+// RidgeGroup. Result must contain 1, 2 or 3 RidgeGroups - impossible to form more groups by removal of only element
+std::vector<RidgeGroup> remove_mesh(RidgeGroup& ridge_group, RidgeMesh* mesh, RidgeConfig config);
 
 }  // namespace sota

--- a/src/ridge_impl/ridge_hex_grid.cpp
+++ b/src/ridge_impl/ridge_hex_grid.cpp
@@ -1,11 +1,15 @@
 #include "ridge_hex_grid.h"
 
-#include <algorithm>   // for find, max, min
+#include <algorithm>  // for find, max, min
+#include <cassert>
 #include <functional>  // for reference_wrapper
-#include <limits>      // for numeric_limits
-#include <memory>      // for make_unique, alloca...
+#include <iterator>
+#include <limits>  // for numeric_limits
+#include <memory>  // for make_unique, alloca...
 #include <numeric>
+#include <optional>
 #include <unordered_map>  // for unordered_map, unor...
+#include <vector>
 
 #include "algo/dsu.h"                  // for DSU
 #include "core/general_utility.h"      // for GeneralUtility
@@ -65,8 +69,12 @@ void RidgeHexGrid::calculate_geometry() {
 
   // print_biomes();
 
-  prepare_heights_calculation();
-  calculate_final_heights();
+  for (RidgeGroup& group : all_groups()) {
+    prepare_heights_calculation(group);
+  }
+  for (RidgeGroup& group : all_groups()) {
+    calculate_final_heights(group);
+  }
   calculate_normals();
 }
 
@@ -255,7 +263,7 @@ void RidgeHexGrid::calculate_offsets() {
       x_offset += is_odd(val.x) ? pointy_top_x_offset(_diameter) / 2 : 0;
 
       auto z_offset = val.x * pointy_top_y_offset(_diameter);
-      _offsets[calculate_id(val.x, val.z)] = Vector3(x_offset, 0, z_offset);
+      _id_to_offset_coordinate[calculate_id(val.x, val.z)] = Vector3(x_offset, 0, z_offset);
     }
   }
 }
@@ -266,7 +274,7 @@ std::vector<std::vector<Biome>> RidgeHexGrid::calculate_biomes() {
     altitudes.push_back({});
     for (auto val : row) {
       int id = calculate_id(val.x, val.z);
-      Vector3 o = _offsets[id];
+      Vector3 o = _id_to_offset_coordinate[id];
       if (_biomes_noise.ptr()) {
         altitudes.back().push_back(_biomes_noise->get_noise_2d(o.x, o.z));
       } else {
@@ -291,10 +299,7 @@ std::vector<std::vector<Biome>> RidgeHexGrid::calculate_biomes() {
   return BiomeCalculator().calculate_biomes(min_z, max_z, altitudes);
 }
 
-BiomeTile* RidgeHexGrid::make_biome_tile(Biome biome, int row, int col) {
-  Vector3i val = _col_row_layout[row][col];
-  int id = calculate_id(val.x, val.z);
-
+Ref<RidgeMesh> RidgeHexGrid::make_biome_mesh(Biome biome, int id, Vector3i layout) {
   Ref<ShaderMaterial> mat;
   mat.instantiate();
   if (_shader.ptr()) {
@@ -311,9 +316,9 @@ BiomeTile* RidgeHexGrid::make_biome_tile(Biome biome, int row, int col) {
     mat->set_shader_parameter("hill_level_ratio", _biomes_hill_level_ratio);
   }
 
-  Hexagon hex = make_hexagon_at_position(_offsets[id], _diameter);
+  Hexagon hex = make_hexagon_at_position(_id_to_offset_coordinate[id], _diameter);
 
-  ClipOptions clip_options = get_clip_options(val.x, val.z);
+  ClipOptions clip_options = get_clip_options(layout.x, layout.z);
   RidgeHexMeshParams params{
       .hex_mesh_params = HexMeshParams{.id = id,
                                        .diameter = _diameter,
@@ -327,7 +332,15 @@ BiomeTile* RidgeHexGrid::make_biome_tile(Biome biome, int row, int col) {
   };
 
   Ref<RidgeMesh> m = create_ridge_mesh(biome, hex, params);
-  return make_non_ref<BiomeTile>(m, this, biome, OffsetCoordinates{.row = val.x, .col = val.z}, row, col);
+  return m;
+}
+
+BiomeTile* RidgeHexGrid::make_biome_tile(Biome biome, int row, int col) {
+  Vector3i val = _col_row_layout[row][col];
+  int id = calculate_id(val.x, val.z);
+
+  return make_non_ref<BiomeTile>(make_biome_mesh(biome, id, val), this, biome,
+                                 OffsetCoordinates{.row = val.x, .col = val.z}, row, col);
 }
 
 void RidgeHexGrid::make_tiles() {
@@ -370,49 +383,158 @@ void RidgeHexGrid::init_biomes() {
 
   BiomeGroups mountain_groups = collect_biome_groups(Biome::MOUNTAIN);
   for (auto group : mountain_groups) {
-    _mountain_groups.emplace_back(group, std::make_unique<RidgeSet>(_ridge_config));
+    _mountain_groups.emplace_back(group, std::make_unique<RidgeSet>(_ridge_config), Biome::MOUNTAIN);
   }
 
   BiomeGroups plain_groups = collect_biome_groups(Biome::PLAIN);
   for (auto group : plain_groups) {
-    _plain_groups.emplace_back(group);
+    _plain_groups.emplace_back(group, Biome::PLAIN);
   }
 
   BiomeGroups hill_groups = collect_biome_groups(Biome::HILL);
   for (auto group : hill_groups) {
-    _hill_groups.emplace_back(group);
+    _hill_groups.emplace_back(group, Biome::HILL);
   }
 
   BiomeGroups water_groups = collect_biome_groups(Biome::WATER);
   for (auto group : water_groups) {
-    _water_groups.emplace_back(group, std::make_unique<RidgeSet>(_ridge_config));
+    _water_groups.emplace_back(group, std::make_unique<RidgeSet>(_ridge_config), Biome::WATER);
   }
 }
 
+RidgeGroup& RidgeHexGrid::get_group(BiomeTile* biome_tile) {
+  Biome biome = biome_tile->biome();
+  std::vector<RidgeGroup>& groups = get_groups_by_biome(biome);
+  for (RidgeGroup& group : groups) {
+    if (group.has(dynamic_cast<RidgeMesh*>(biome_tile->mesh().ptr()))) {
+      return group;
+    }
+  }
+  printerr("Not reachable, can't get group by biome tile");
+  return _plain_groups[0];
+}
+
+BiomeTile* RidgeHexGrid::get_biome_tile(TileMesh* target) {
+  for (auto& vec : _tiles_layout) {
+    for (Tile* tile : vec) {
+      if (tile->mesh().ptr() == target) {
+        return dynamic_cast<BiomeTile*>(tile);
+      }
+    }
+  }
+
+  printerr("can't find BiomeTile by TileMesh*");  // should be never reached
+  return nullptr;
+}
+
+void RidgeHexGrid::update_biome_groups(std::vector<RidgeGroup*> to_be_removed, std::vector<RidgeGroup>& to_be_added,
+                                       Biome biome) {
+  std::vector<RidgeGroup>& groups_to_be_modified = get_groups_by_biome(biome);
+  subtract(groups_to_be_modified, to_be_removed);
+  groups_to_be_modified.insert(groups_to_be_modified.cend(), std::make_move_iterator(to_be_added.begin()),
+                               std::make_move_iterator(to_be_added.end()));
+}
+
+void RidgeHexGrid::update_biome(BiomeTile* biome_tile, Biome new_biome) {
+  // Remove mesh from old group
+  RidgeGroup& old_group = get_group(biome_tile);
+  Biome old_biome = biome_tile->biome();
+  std::vector<RidgeGroup> groups_after_mesh_removal =
+      remove_mesh(old_group, dynamic_cast<RidgeMesh*>(biome_tile->mesh().ptr()), _ridge_config);
+  for (RidgeGroup& g : groups_after_mesh_removal) {
+    prepare_heights_calculation(g);
+    calculate_final_heights(g);
+  }
+  update_biome_groups({&old_group}, groups_after_mesh_removal, old_biome);
+
+  // Update mesh
+  int row = biome_tile->row();
+  int col = biome_tile->col();
+  Vector3i val = _col_row_layout[row][col];
+  int id = calculate_id(val.x, val.z);
+  Ref<RidgeMesh> new_mesh = make_biome_mesh(new_biome, id, val);
+  biome_tile->replace_mesh(new_mesh);
+  biome_tile->set_biome(new_biome);
+  _cube_coord_to_tile_mesh[biome_tile->get_cube_coords()] = biome_tile->mesh().ptr();
+
+  // Collect groups of neighbouring tiles which have same biome
+  int i = 0;
+  std::vector<RidgeGroup*> groups_to_join;
+  Neighbours biome_tile_neighbours = get_neighbours(biome_tile, {});
+  for (TileMesh* neighbour_tile_mesh : biome_tile_neighbours) {
+    if (!neighbour_tile_mesh) {
+      continue;  // it's OK e.g. for border tiles
+    }
+
+    BiomeTile* neighbour_biome_tile = get_biome_tile(neighbour_tile_mesh);
+    if (!neighbour_biome_tile) {
+      continue;  // always not OK, error will be print from 'get_biome_tile'
+    }
+    RidgeGroup& group = get_group(neighbour_biome_tile);
+    Biome biome = neighbour_biome_tile->biome();
+    if (biome == new_biome && std::find(groups_to_join.begin(), groups_to_join.end(), &group) == groups_to_join.end()) {
+      groups_to_join.push_back(&group);
+    }
+
+    ++i;
+  }
+
+  // Combine groups of neighbouring tiles: if found combine multiple groups into one, produce new RidgeGroup from single
+  // mesh otherwise
+  std::vector<RidgeGroup> to_be_added;
+  std::optional<RidgeGroup> combined = combine(groups_to_join, _ridge_config);
+  RidgeMesh* new_ridge_mesh = dynamic_cast<RidgeMesh*>(biome_tile->mesh().ptr());
+  if (combined.has_value()) {
+    combined->add(new_ridge_mesh);
+    prepare_heights_calculation(combined.value());
+    calculate_final_heights(combined.value());
+
+    to_be_added.emplace_back(std::move(combined.value()));
+    update_biome_groups(groups_to_join /*to be deleted*/, to_be_added /*to be added*/, new_biome);
+  } else {
+    RidgeGroup new_group = (new_biome == Biome::MOUNTAIN || new_biome == Biome::WATER)
+                               ? RidgeGroup({new_ridge_mesh}, std::make_unique<RidgeSet>(_ridge_config), new_biome)
+                               : RidgeGroup({new_ridge_mesh}, new_biome);
+    prepare_heights_calculation(new_group);
+    calculate_final_heights(new_group);
+
+    to_be_added.emplace_back(std::move(new_group));
+    update_biome_groups({} /*to be deleted*/, to_be_added /* to be added*/, new_biome);
+  }
+
+  calculate_normals();
+}
+
+static bool is_member_of_group(const GroupOfRidgeMeshes* group, TileMesh* tile_mesh) {
+  RidgeMesh* ridge_mesh = dynamic_cast<RidgeMesh*>(tile_mesh);
+  return std::find(group->begin(), group->end(), ridge_mesh) != group->end();
+};
+
+Neighbours RidgeHexGrid::get_neighbours(BiomeTile* biome_tile, std::optional<const GroupOfRidgeMeshes*> group) {
+  CubeCoordinates cube_cur = biome_tile->get_cube_coords();
+  Neighbours hexagon_neighbours = {nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
+  std::vector<CubeCoordinates> neighbours_hexes_coord = neighbours(cube_cur);
+
+  for (unsigned int i = 0; i < neighbours_hexes_coord.size(); ++i) {
+    CubeCoordinates n = neighbours_hexes_coord[i];
+    bool check_group = group.has_value() ? is_member_of_group(group.value(), _cube_coord_to_tile_mesh[n]) : true;
+    if (_cube_coord_to_tile_mesh.contains(n) && check_group) {
+      hexagon_neighbours[i] = _cube_coord_to_tile_mesh[n];
+    }
+  }
+  return hexagon_neighbours;
+}
+
 void RidgeHexGrid::calculate_neighbours(const GroupOfRidgeMeshes& group) {
-  auto member_of_group = [&group](RidgeMesh& ridge_hex_mesh) {
-    return std::find(group.begin(), group.end(), &ridge_hex_mesh) != group.end();
-  };
   for (auto& row : _tiles_layout) {
     for (auto& tile_ptr : row) {
       BiomeTile* tile = dynamic_cast<BiomeTile*>(tile_ptr);
       RidgeMesh* ridge_hex_mesh = dynamic_cast<RidgeMesh*>(tile->mesh().ptr());
-      if (std::find(group.begin(), group.end(), ridge_hex_mesh) == group.end()) {
+      if (!is_member_of_group(&group, tile->mesh().ptr())) {
         continue;
       }
-      CubeCoordinates cube_cur = tile->get_cube_coords();
-      Neighbours hexagon_neighbours = {nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
-      std::vector<CubeCoordinates> neighbours_hexes_coord = neighbours(cube_cur);
 
-      for (unsigned int i = 0; i < neighbours_hexes_coord.size(); ++i) {
-        CubeCoordinates n = neighbours_hexes_coord[i];
-        RidgeMesh* casted = dynamic_cast<RidgeMesh*>(_cube_to_hexagon[n]);
-        if (_cube_to_hexagon.contains(n) && member_of_group(*casted) && member_of_group(*ridge_hex_mesh)) {
-          hexagon_neighbours[i] = _cube_to_hexagon[n];
-        }
-      }
-
-      tile->set_neighbours(hexagon_neighbours);
+      tile->set_neighbours(get_neighbours(tile, std::make_optional(&group)));
     }
   }
 }
@@ -422,7 +544,7 @@ void RidgeHexGrid::assign_neighbours(const GroupOfRidgeMeshes& group) {
     for (auto& tile_ptr : row) {
       BiomeTile* tile = dynamic_cast<BiomeTile*>(tile_ptr);
       RidgeMesh* ridge_mesh = dynamic_cast<RidgeMesh*>(tile->mesh().ptr());
-      if (std::find(group.begin(), group.end(), ridge_mesh) == group.end()) {
+      if (!is_member_of_group(&group, tile->mesh().ptr())) {
         continue;
       }
       ridge_mesh->set_neighbours(tile->neighbours());
@@ -436,61 +558,54 @@ void RidgeHexGrid::init_ridges(std::vector<RidgeGroup>& group, float ridge_offse
   }
 }
 
-void RidgeHexGrid::prepare_heights_calculation() {
-  for (RidgeGroup& group : all_groups()) {
-    calculate_neighbours(group.meshes());
-    assign_neighbours(group.meshes());
+void RidgeHexGrid::prepare_heights_calculation(RidgeGroup& group) {
+  calculate_neighbours(group.meshes());
+  assign_neighbours(group.meshes());
+  if (group.has_ridge_set()) {
+    auto offset = group.biome() == Biome::MOUNTAIN ? _ridge_config.top_ridge_offset : _ridge_config.bottom_ridge_offset;
+    group.init_ridges(_distance_map, offset, _divisions);
   }
-  init_ridges(_mountain_groups, _ridge_config.top_ridge_offset);
-  init_ridges(_water_groups, _ridge_config.bottom_ridge_offset);
 
-  float global_min_y = std::numeric_limits<float>::max();
-  float global_max_y = std::numeric_limits<float>::min();
-  auto calculate_initial = [&global_max_y, &global_min_y](const GroupOfRidgeMeshes& group) {
+  auto calculate_initial = [this](const GroupOfRidgeMeshes& group) {
     for (auto* mesh : group) {
       mesh->calculate_initial_heights();
       auto [mesh_min_z, mesh_max_z] = mesh->get_min_max_height();
-      global_min_y = std::min(global_min_y, mesh_min_z);
-      global_max_y = std::max(global_max_y, mesh_max_z);
+      _global_min_y = std::min(_global_min_y, mesh_min_z);
+      _global_max_y = std::max(_global_max_y, mesh_max_z);
     }
   };
-  for (RidgeGroup& group : all_groups()) {
-    group.fmap(calculate_initial);
-  }
+  group.fmap(calculate_initial);
 
-  float amplitude = global_max_y - global_min_y;
+  float amplitude = _global_max_y - _global_min_y;
   float compression_factor = _biomes_plain_hill_gain / amplitude;
 
-  auto shift_compress = [global_min_y, compression_factor](const GroupOfRidgeMeshes& group) {
+  auto shift_compress = [this, compression_factor](const GroupOfRidgeMeshes& group) {
     for (auto* mesh : group) {
-      mesh->set_shift_compress(-global_min_y, compression_factor);
+      mesh->set_shift_compress(-_global_min_y, compression_factor);
     }
   };
 
-  for (RidgeGroup& group : all_groups()) {
-    group.fmap(shift_compress);
-  }
+  group.fmap(shift_compress);
 }
 
 void RidgeHexGrid::assign_cube_coordinates_map() {
   for (auto& row : _tiles_layout) {
     for (auto& tile_ptr : row) {
       BiomeTile* tile = dynamic_cast<BiomeTile*>(tile_ptr);
-      _cube_to_hexagon[tile->get_cube_coords()] = tile_ptr->mesh().ptr();
+      _cube_coord_to_tile_mesh[tile->get_cube_coords()] = tile_ptr->mesh().ptr();
     }
   }
 }
 
-void RidgeHexGrid::calculate_final_heights() {
-  for (auto& row : _tiles_layout) {
-    for (auto& tile_ptr : row) {
-      RidgeMesh* mesh = dynamic_cast<RidgeMesh*>(tile_ptr->mesh().ptr());
-
-      mesh->calculate_final_heights(_distance_map, _diameter, _divisions);
-      mesh->calculate_normals();
-      mesh->update();
+void RidgeHexGrid::calculate_final_heights(RidgeGroup& group) {
+  auto update_vertices = [this](GroupOfRidgeMeshes& group_of_ridge_meshes) {
+    for (RidgeMesh* ridge_mesh : group_of_ridge_meshes) {
+      ridge_mesh->calculate_final_heights(_distance_map, _diameter, _divisions);
+      ridge_mesh->calculate_normals();
+      ridge_mesh->update();
     }
-  }
+  };
+  group.fmap_mutable(update_vertices);
 }
 
 // RectRidgeHexGrid definitions
@@ -555,13 +670,13 @@ BiomeGroups RectRidgeHexGrid::collect_biome_groups(Biome b) {
       RidgeMesh* mesh = dynamic_cast<RidgeMesh*>(tile->mesh().ptr());
       u.push(flat(i, j), mesh);
       u.make_union(flat(i, j), flat(i - 1, j));
-      if (_cube_to_hexagon.contains(offsetToCube(OffsetCoordinates{i - 1, j + 1}))) {
+      if (_cube_coord_to_tile_mesh.contains(offsetToCube(OffsetCoordinates{i - 1, j + 1}))) {
         u.make_union(flat(i, j), flat(i - 1, j + 1));
       }
-      if (_cube_to_hexagon.contains(offsetToCube(OffsetCoordinates{i - 1, j - 1}))) {
+      if (_cube_coord_to_tile_mesh.contains(offsetToCube(OffsetCoordinates{i - 1, j - 1}))) {
         u.make_union(flat(i, j), flat(i - 1, j - 1));
       }
-      if (_cube_to_hexagon.contains(offsetToCube(OffsetCoordinates{i, j - 1}))) {
+      if (_cube_coord_to_tile_mesh.contains(offsetToCube(OffsetCoordinates{i, j - 1}))) {
         u.make_union(flat(i, j), flat(i, j - 1));
       }
     }
@@ -592,12 +707,10 @@ void RectRidgeHexGrid::set_biomes(String str, int row_num, int col_num) {
     }
   }
 
-  _tiles_layout.clear();
-  clean_children(*this);
-  _tiles_layout = std::vector<std::vector<Tile*>>(row_num, std::vector<Tile*>(col_num, nullptr));
   for (int i = 0; i < n; ++i) {
     int row = i / row_num;
     int col = i % col_num;
+    _tiles_layout[row][col]->destroy();
     char c = str[i];
     switch (c) {
       case 'P':
@@ -660,13 +773,13 @@ BiomeGroups HexagonalRidgeHexGrid::collect_biome_groups(Biome b) {
       RidgeMesh* mesh = dynamic_cast<RidgeMesh*>(tile->mesh().ptr());
       u.push(flat(i, j), mesh);
       u.make_union(flat(i, j), flat(i - 1, j));
-      if (_cube_to_hexagon.contains(offsetToCube(OffsetCoordinates{i - 1, j + 1}))) {
+      if (_cube_coord_to_tile_mesh.contains(offsetToCube(OffsetCoordinates{i - 1, j + 1}))) {
         u.make_union(flat(i, j), flat(i - 1, j + 1));
       }
-      if (_cube_to_hexagon.contains(offsetToCube(OffsetCoordinates{i - 1, j - 1}))) {
+      if (_cube_coord_to_tile_mesh.contains(offsetToCube(OffsetCoordinates{i - 1, j - 1}))) {
         u.make_union(flat(i, j), flat(i - 1, j - 1));
       }
-      if (_cube_to_hexagon.contains(offsetToCube(OffsetCoordinates{i, j - 1}))) {
+      if (_cube_coord_to_tile_mesh.contains(offsetToCube(OffsetCoordinates{i, j - 1}))) {
         u.make_union(flat(i, j), flat(i, j - 1));
       }
     }

--- a/src/ridge_impl/ridge_hex_grid.h
+++ b/src/ridge_impl/ridge_hex_grid.h
@@ -13,6 +13,7 @@
 #include "ridge_impl/ridge_group.h"         // for BiomeGroups, GroupOfRidge...
 #include "ridge_impl/ridge_set.h"
 #include "ridge_impl/terraformer.h"
+#include "ridge_mesh.h"
 #include "tal/godot_core.h"
 #include "tal/noise.h"      // for FastNoiseLite
 #include "tal/reference.h"  // for Ref
@@ -80,7 +81,9 @@ class RidgeHexGrid : public HexGrid, public RidgeBased {
 
   std::vector<Ref<MatrixProcessor>> _tile_processors;
 
-  BiomeTile* make_biome_tile(Biome biome, int row, int col);
+  void update_biome(BiomeTile* biome_tile, Biome new_biome);
+
+  Neighbours get_neighbours(BiomeTile* biome_tile, std::optional<const GroupOfRidgeMeshes*> group);
 
  protected:
   friend BiomeTile;  // It's OK for BiomeTiles to ping their parent, e.g. in 'on_click' handler
@@ -89,7 +92,6 @@ class RidgeHexGrid : public HexGrid, public RidgeBased {
     for (Ref<MatrixProcessor> processor : _tile_processors) {
       processor->process(row, col);
     }
-    calculate_geometry();
   }
 
   DiscreteVertexToDistance _distance_map;
@@ -99,6 +101,8 @@ class RidgeHexGrid : public HexGrid, public RidgeBased {
   void init() override;
   void calculate_geometry();
   void make_tiles() override;
+
+  BiomeTile* make_biome_tile(Biome biome, int row, int col);
 
  private:
   std::unordered_map<Biome, Ref<Texture>> _texture;
@@ -110,7 +114,10 @@ class RidgeHexGrid : public HexGrid, public RidgeBased {
   bool _smooth_normals{false};
   float _biomes_hill_level_ratio{0.7};
   float _biomes_plain_hill_gain{0.1f};
-  std::unordered_map<int, Vector3> _offsets;
+  std::unordered_map<int, Vector3> _id_to_offset_coordinate;
+
+  float _global_min_y = std::numeric_limits<float>::max();
+  float _global_max_y = std::numeric_limits<float>::min();
 
   void calculate_neighbours(const GroupOfRidgeMeshes& group);
   void assign_neighbours(const GroupOfRidgeMeshes& group);
@@ -120,8 +127,8 @@ class RidgeHexGrid : public HexGrid, public RidgeBased {
   virtual ClipOptions get_clip_options(int row, int col) const = 0;
 
   void init_biomes();
-  void prepare_heights_calculation();
-  void calculate_final_heights();
+  void prepare_heights_calculation(RidgeGroup& group);
+  void calculate_final_heights(RidgeGroup& group);
 
   void assign_cube_coordinates_map();
   void calculate_normals() override;
@@ -129,6 +136,12 @@ class RidgeHexGrid : public HexGrid, public RidgeBased {
   std::vector<std::vector<Biome>> calculate_biomes();
 
   std::vector<TileMesh*> meshes();
+
+  Ref<RidgeMesh> make_biome_mesh(Biome biome, int id, Vector3i layout);
+  RidgeGroup& get_group(BiomeTile* biome_tile);
+  BiomeTile* get_biome_tile(TileMesh* target);
+  void update_biome_groups(std::vector<RidgeGroup*> groups_to_be_removed, std::vector<RidgeGroup>& to_be_added,
+                           Biome biome);
 };
 
 class RectRidgeHexGrid : public RidgeHexGrid {

--- a/src/ridge_impl/ridge_mesh.h
+++ b/src/ridge_impl/ridge_mesh.h
@@ -71,6 +71,8 @@ class RidgeMesh : public TileMesh {
   Vector3 get_center() { return _mesh->get_center(); }
   SotaMesh* inner_mesh() const override { return _mesh.ptr(); }
 
+  void remove_neighbour(RidgeMesh* neighbour) { std::erase(_neighbours, neighbour); }
+
   int get_id() override { return _mesh->get_id(); }
 
  protected:

--- a/src/ridge_impl/terraformer.cpp
+++ b/src/ridge_impl/terraformer.cpp
@@ -1,12 +1,16 @@
 #include "ridge_impl/terraformer.h"
 
 #include "ridge_impl/ridge_hex_grid.h"
+#include "tile.h"
 
 namespace sota {
 
 void Terraformer::process(int row, int col) {
-  (*_tiles_layout)[row][col]->destroy();
-  (*_tiles_layout)[row][col] = _ridge_hex_grid->make_biome_tile(_biome_to_set, row, col);
+  BiomeTile *biome_tile = dynamic_cast<BiomeTile *>((*_tiles_layout)[row][col]);
+  if (biome_tile->biome() == _biome_to_set) {
+    return;
+  }
+  _ridge_hex_grid->update_biome(biome_tile, _biome_to_set);
 }
 
 }  // namespace sota

--- a/src/tal/event.h
+++ b/src/tal/event.h
@@ -2,11 +2,15 @@
 
 #ifdef SOTA_GDEXTENSION
 #include "godot_cpp/classes/global_constants.hpp"
+#include "godot_cpp/classes/input.hpp"
 #include "godot_cpp/classes/input_event.hpp"
 #include "godot_cpp/classes/input_event_mouse.hpp"
 
 using InputEvent = godot::InputEvent;
+using Input = godot::Input;
 using InputEventMouse = godot::InputEventMouse;
+
+constexpr godot::MouseButton MOUSE_BUTTON_LEFT = godot::MOUSE_BUTTON_LEFT;
 
 constexpr godot::MouseButtonMask MOUSE_BUTTON_MASK_LEFT = godot::MouseButtonMask::MOUSE_BUTTON_MASK_LEFT;
 constexpr godot::MouseButtonMask MOUSE_BUTTON_MASK_RIGHT = godot::MouseButtonMask::MOUSE_BUTTON_MASK_RIGHT;


### PR DESCRIPTION
When BiomeTile A surrounded by other BiomeTiles B, C, D, E, F, G (which are
parts of some RidgeGroups, maybe the same as A) changes biome, only
neighbouring RidgeGroups have to be adjusted:
1. A connects 2 or 3 groups which had no connection
2. A makes no changes to groups of it's neighbours
3. A splits existing group into 2 or 3 pieces
4. A splits one RidgeGroup and connects other(s) - combo of 1. and 3.

Add feature to demo.
* Implemented before. Choose target biome and click on tile to change it's
  biome to target biome.
* New. Choose target biome and move mouse curson while left button is
  pressed to change biomes of tiles to target biome

Resolves: #80 