### PR TITLE
Fix builds for export templates and unix-based platforms

### DIFF
--- a/src/ridge_impl/plain_mesh.h
+++ b/src/ridge_impl/plain_mesh.h
@@ -11,6 +11,7 @@
 namespace sota {
 
 class PlainMesh : public RidgeMesh {
+  GDCLASS(PlainMesh, RidgeMesh)
  public:
   PlainMesh(Hexagon hex, RidgeHexMeshParams params) : RidgeMesh(hex, params) {}
   PlainMesh(Pentagon pentagon, RidgePentagonMeshParams params) : RidgeMesh(pentagon, params) {}

--- a/src/tal/engine.h
+++ b/src/tal/engine.h
@@ -8,6 +8,8 @@ using Engine = godot::Engine;
 using EditorInterface = godot::EditorInterface;
 
 #else
+#ifdef SOTA_ENGINE
 #include "editor/editor_interface.h"
+#endif
 #include "core/config/engine.h"
 #endif

--- a/src/tal/godot_core.h
+++ b/src/tal/godot_core.h
@@ -44,7 +44,9 @@ auto printerr(Args&&... args) -> decltype(UtilityFunctions::print(std::forward<A
 #include "core/os/memory.h"
 #include "core/string/print_string.h"
 #include "core/variant/variant_utility.h"
+#ifdef SOTA_ENGINE
 #include "editor/editor_interface.h"
+#endif
 #include "modules/register_module_types.h"
 
 template <typename... Args>


### PR DESCRIPTION
This makes so no editor interfaces are included on non-editor builds, so it passes when building for both, editor and templates, plus solves inheritance problem on clang (and possibly gcc?).